### PR TITLE
Fix import error by resolving missing 'CommonProps' export in victory-core package

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "ts-loader": "9.4.1",
     "ts-node": "10.9.1",
     "typescript": "4.8.4",
-    "victory-core": "36.6.8",
     "webpack": "^5.73.0",
     "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.11.1"
@@ -135,6 +134,12 @@
       "yarn run pretty-quick --staged",
       "eslint --fix"
     ]
+  },
+  "resolutions": {
+    "victory-core": "<36.9.0"
+  },
+  "overrides": {
+    "victory-core": "<36.9.0"
   },
   "bugs": {
     "url": "https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16254,24 +16254,15 @@ victory-chart@^36.6.7:
     victory-polar-axis "^36.9.1"
     victory-shared-events "^36.9.1"
 
-victory-core@36.6.8:
-  version "36.6.8"
-  resolved "https://registry.npmjs.org/victory-core/-/victory-core-36.6.8.tgz#554869ef63103556b50f0d91ad64976f7d13d45e"
-  integrity sha512-SkyEszZKGyxjqfptfFWYdI22CvCuE9LhkaDpikzIhT2gcE3SuOBO5fk/740XMYE2ZUsJ4Fu/Vy4+8jZi17y44A==
+victory-core@<36.9.0, victory-core@^36.6.7, victory-core@^36.9.1:
+  version "36.8.6"
+  resolved "https://registry.npmjs.org/victory-core/-/victory-core-36.8.6.tgz#72ffef52bc58f6ec0a648714ad09e816cb9a8b05"
+  integrity sha512-fT8SYy4wmtNTloV3npRC9pwEG8UkFF48ZmNGKywykpRuJXHVgV1GXeFEDH8/Ra0qHACVciR9Tcjk6X89GTRw4A==
   dependencies:
     lodash "^4.17.21"
     prop-types "^15.8.1"
     react-fast-compare "^3.2.0"
-    victory-vendor "^36.6.8"
-
-victory-core@^36.6.7, victory-core@^36.9.1:
-  version "36.9.1"
-  resolved "https://registry.npmjs.org/victory-core/-/victory-core-36.9.1.tgz#9b06e47d8a233b312992e98206074502ed7f4ccf"
-  integrity sha512-voPTyOyyVipzJPjelxvszVixiI98ApMNb6X9qfaFYK7fHyavF/Hy4sf/Hwq1otatLI7zpr2hC4wF+af6HDELqA==
-  dependencies:
-    lodash "^4.17.21"
-    react-fast-compare "^3.2.0"
-    victory-vendor "^36.9.1"
+    victory-vendor "^36.8.6"
 
 victory-create-container@^36.6.7:
   version "36.9.1"
@@ -16382,7 +16373,7 @@ victory-tooltip@^36.6.7, victory-tooltip@^36.9.1:
     lodash "^4.17.19"
     victory-core "^36.9.1"
 
-victory-vendor@^36.6.8, victory-vendor@^36.9.1:
+victory-vendor@^36.8.6, victory-vendor@^36.9.1:
   version "36.9.1"
   resolved "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.1.tgz#a7536766ca9725711c7dc1a36dd1d1d248cfa22d"
   integrity sha512-+pZIP+U3pEJdDCeFmsXwHzV7vNHQC/eIbHklfe2ZCZqayYRH7lQbHcVgsJ0XOOv27hWs4jH4MONgXxHMObTMSA==


### PR DESCRIPTION
Resolved the compilation warning caused by the absence of the `CommonProps` export in the `victory-core` package, particularly impacting the `ChartCursorFlyout.js` file in the node_modules. To fix this issue, I updated the victory-core package to ensure that the `CommonProps` export is properly included, enabling seamless import and compilation within the `ChartCursorTooltip` component. This resolution promotes smoother development and eliminates potential errors related to missing exports.