### PR TITLE
Updated OCP Version from 4.14.0 to latest in start-console-tls.sh file

### DIFF
--- a/start-console-tls.sh
+++ b/start-console-tls.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:4.14.0"}
+CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
 CONSOLE_PORT=${CONSOLE_PORT:=9442}
 
 echo "Starting local OpenShift console in https mode..."


### PR DESCRIPTION
In the `start-console-tls.sh` file, the OCP image version is currently set to `4.14.0.` I have updated it to the `latest` tag version.