### PR TITLE
[#119] doc: add details on the OpenShift setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,89 @@ This project is a ActiveMQ Artemis Self Provisioning Plugin to the Administrator
 
 ## Local development
 
+To be able to run the local development environment you need to:
+* have access to a local or remote OpenShift cluster
+* have the operator installed on the cluster
+* have the cert-manager operator installed on the cluster
+* have the plugin running
+* have the console running
+
+### Setting up an OpenShift cluster
+
+In order to run the project you need to have access to an OpenShift cluster.
+If you don't have an access to a remote one you can deploy one on your machine
+with `crc`.
+
+#### Local cluster
+
+Follow the documentation:
+https://access.redhat.com/documentation/en-us/red_hat_openshift_local/2.34/html-single/getting_started_guide/index#introducing
+
+> [!WARNING]
+> If you're encountering an issue where `crc` gets stuck in the step `Waiting
+> for kube-apiserver availability` or `Waiting until the user's pull secret is
+> written to the instance disk...` [you might
+> need](https://github.com/crc-org/crc/issues/4110) to
+> configure the network as local: `crc config set network-mode user`
+
+Once your environment is set up you simply need to `crc start` your cluster.
+
+#### Connecting to the cluster
+
+Depending on the remote or local env:
+
+* `oc login -u kubeadmin
+https://api.ci-ln-x671mxk-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443` (to
+adapt depending on your cluster address)
+* `oc login -u kubeadmin https://api.crc.testing:6443`
+
+### Installing the operator
+
+The plugin requires having access to the operator to function. You can either
+get the operator from the operatorHub or from the upstream repo.
+
+#### From the operatorHub
+
+Navigate to the operatorHub on the console and search for: `Red Hat Integration
+- AMQ Broker for RHEL 8 (Multiarch)` After installation the wait for the
+operator container to be up and running.
+
+> [!WARNING]
+> If you're running into an issue where the operatorHub is not accessible, try
+> to force its redeployment: `oc delete pods --all -n openshift-marketplace`
+> see https://github.com/crc-org/crc/issues/4109 for reference.
+
+#### From the upstream repository
+
+Clone the operator repository then run `./deploy/install_opr.sh` to install the
+operator onto your cluster.
+
+```
+git clone git@github.com:artemiscloud/activemq-artemis-operator.git
+cd activemq-artemis-operator
+./deploy/install_opr.sh
+```
+
+> [!TIP]
+> If you need to redeploy the operator, first call `./deploy/undeploy_all.sh`
+
+> [!IMPORTANT]
+> The script `install_opr.sh` will try to deploy on OpenShift with the `oc`
+> command. If it's not available it will fallback to `kubectl`. Make sure your
+> OpenShift cluster is up and running and that `oc` is connected to it before
+> running the install.
+
+### Installing the cert-manager operator
+
+The plugin requires having access to the cert-manager operator for certain of
+its functionalities.
+
+#### From the operatorHub
+
+Navigate to the operatorHub on the console and search for `Cert-manager`.
+
+### Running the plugin
+
 In one terminal window, run:
 
 1. `yarn install`
@@ -19,7 +102,7 @@ if you want the plugin to run in https mode, run
 In another terminal window, run:
 
 1. `oc login`
-2. `yarn run start-console` (requires [Docker](https://www.docker.com) or [podman](https://podman.io))
+2. `yarn run start-console` (requires [Docker](https://www.docker.com) or [podman](https://podman.io) or another [Open Containers Initiative](https://opencontainers.org/) compatible container runtime)
 
 This will run the OpenShift console in a container connected to the cluster
 you've logged into. The plugin HTTP server runs on port 9001 with CORS enabled.


### PR DESCRIPTION
Add details on the documentation about setting up an OpenShift cluster and how to deploy the operator on it. These two steps being requirements for running the plugin successfully.