### PR TITLE
[#121] harden the eslint config

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ env:
 extends:
   - eslint:recommended
   - plugin:react/recommended
+  - plugin:react-hooks/recommended
   - plugin:@typescript-eslint/recommended
   - prettier
 parser: '@typescript-eslint/parser'
@@ -19,6 +20,7 @@ plugins:
   - react
   - '@typescript-eslint'
 rules:
+  eqeqeq: error
   prettier/prettier:
     - error
   react/react-in-jsx-scope: 'off'

--- a/src/brokers/broker-details/index.ts
+++ b/src/brokers/broker-details/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./BrokerDetails.container";
+export { default } from './BrokerDetails.container';

--- a/src/metrics/components/ChartPopover/ChartPopover.test.tsx
+++ b/src/metrics/components/ChartPopover/ChartPopover.test.tsx
@@ -8,7 +8,7 @@ describe('ChartPopover', () => {
     );
     await waitForI18n(comp);
     expect(
-      screen.getByLabelText('chart_popover_icon_screenreader_text')
+      screen.getByLabelText('chart_popover_icon_screenreader_text'),
     ).toBeInTheDocument();
   });
 });

--- a/src/metrics/components/ChartSkeletonLoader/ChartSkeletonLoader.test.tsx
+++ b/src/metrics/components/ChartSkeletonLoader/ChartSkeletonLoader.test.tsx
@@ -6,7 +6,7 @@ describe('ChartSkeletonLoader', () => {
     const comp = render(<ChartSkeletonLoader />);
     await waitForI18n(comp);
     expect(
-      comp.getByText('skeleton_loader_screenreader_text')
+      comp.getByText('skeleton_loader_screenreader_text'),
     ).toBeInTheDocument();
   });
 });

--- a/src/metrics/hooks/useFetchCpuUsageMetrics.tsx
+++ b/src/metrics/hooks/useFetchCpuUsageMetrics.tsx
@@ -29,6 +29,19 @@ export const useFetchCpuUsageMetrics = (
   return ({ name, namespace, span, samples, endTime, timeout, delay }) => {
     [...Array(n)].map((_, i) => {
       const query = cpuUsageQuery(name, namespace, i);
+      // Normally it is impossible to call a hook in a conditional branch (if,
+      // loops). That is because it would mess with how React stores it's data.
+      // https://react.dev/reference/rules/rules-of-hooks
+      //
+      // However in this specific configuration, the number `n` determining how
+      // many loops are going to occur gets defined by the number of pods within
+      // the deployment. This means this number is guaranteed to stay the same
+      // while the page is up and running, as long as there is no support for
+      // hot reloading.
+      //
+      // That said, it means that it is therefore safe to use this hook in this
+      // loop.
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       const [result, loaded] = usePrometheusPoll({
         endpoint: PrometheusEndpoint.QUERY_RANGE,
         query,

--- a/src/metrics/hooks/useFetchMemoryUsageMetrics.tsx
+++ b/src/metrics/hooks/useFetchMemoryUsageMetrics.tsx
@@ -31,6 +31,19 @@ export const useFetchMemoryUsageMetrics = (
   return ({ name, namespace, span, samples, endTime, timeout, delay }) => {
     [...Array(n)].map((_, i) => {
       const query = memoryUsageQuery(name, namespace, i);
+      // Normally it is impossible to call a hook in a conditional branch (if,
+      // loops). That is because it would mess with how React stores it's data.
+      // https://react.dev/reference/rules/rules-of-hooks
+      //
+      // However in this specific configuration, the number `n` determining how
+      // many loops are going to occur gets defined by the number of pods within
+      // the deployment. This means this number is guaranteed to stay the same
+      // while the page is up and running, as long as there is no support for
+      // hot reloading.
+      //
+      // That said, it means that it is therefore safe to use this hook in this
+      // loop.
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       const [result, loaded] = usePrometheusPoll({
         endpoint: PrometheusEndpoint.QUERY_RANGE,
         query,

--- a/src/shared-components/QueryBrowser/QueryBrowser.tsx
+++ b/src/shared-components/QueryBrowser/QueryBrowser.tsx
@@ -76,7 +76,10 @@ export const QueryBrowser: FC<QueryBrowserProps> = ({
   const domain = { x: fixedXDomain, y: fixedXDomain };
   const xAxisTickCount = Math.round(width / 100);
 
-  const newResult = _.map(allMetricsSeries, 'data.result');
+  //const newResult = _.map(allMetricsSeries, 'data.result');
+  const newResult = allMetricsSeries.map((metric) => {
+    return metric.data.result;
+  });
   const hasMetrics = _.some(newResult, (r) => (r && r.length) > 0);
 
   // Only update X-axis if the time range (fixedXDomain or span) or graph data (allSeries) change

--- a/src/stories/button.css
+++ b/src/stories/button.css
@@ -7,23 +7,28 @@
   display: inline-block;
   line-height: 1;
 }
+
 .storybook-button--primary {
   color: white;
   background-color: #1ea7fd;
 }
+
 .storybook-button--secondary {
   color: #333;
   background-color: transparent;
-  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
+  box-shadow: rgb(0 0 0 / 15%) 0 0 0 1px inset;
 }
+
 .storybook-button--small {
   font-size: 12px;
   padding: 10px 16px;
 }
+
 .storybook-button--medium {
   font-size: 14px;
   padding: 11px 20px;
 }
+
 .storybook-button--large {
   font-size: 16px;
   padding: 12px 24px;

--- a/src/stories/header.css
+++ b/src/stories/header.css
@@ -1,6 +1,6 @@
 .wrapper {
   font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom: 1px solid rgb(0 0 0 / 10%);
   padding: 15px 20px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
This commit adds:
* the react-hooks plugin to the configuration
* the eqeqeq to the configuration

Also two issues regarding the react-hooks were treated:

Normally it is impossible to call a hook in a conditional branch (if,
loops, ...). That is because it would mess with how React stores it's
data. https://react.dev/reference/rules/rules-of-hooks However in this
specific configuration, the number determining how many loops are
going to occur gets defined by the number of pods within the deployment.
This means this number is guaranteed to stay the same while the page is
displayed, as long as there is no support for the hot reloading of the
deployment details.


/!\ I ran the linter with `yarn lint` and some files got modified along the way.