### PR TITLE
Fixed error while running the plugin in the local development env using remote credentials

### DIFF
--- a/src/brokers/view-brokers/components/BrokersList/BrokerRow.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokerRow.tsx
@@ -31,11 +31,10 @@ export const BrokerRow: FC<BrokerRowProps> = ({
   const { t } = useTranslation();
   const {
     metadata: { name, creationTimestamp, namespace },
-    spec: {
-      deploymentPlan: { size },
-    },
     status,
   } = obj;
+
+  const size = obj.spec?.deploymentPlan?.size;
 
   const readyCondition = status
     ? getCondition(obj.status.conditions, BrokerConditionTypes.Ready)


### PR DESCRIPTION
on the remote cluster, there is a broker created without `spec` field. it checks the `spec` field as it's not defined in the broker it prompts error with undefined `deployment` and undefined `size ` on the console.
with some adjustments in the code the issue is fixed.