### PR TITLE
Implement PodsList Page with User-Selectable Broker Pod for Jolokia Endpoint Access

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -29,10 +29,21 @@
   {
     "type": "console.page/route",
     "properties": {
-      "exact": false,
+      "exact": true,
       "path": [
         "/k8s/ns/:ns/brokers/:name",
         "/k8s/all-namespaces/brokers/:name"
+      ],
+      "component": { "$codeRef": "PodsListPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": false,
+      "path": [
+        "/k8s/ns/:ns/broker-pods/:brokerName/:podName",
+        "/k8s/all-namespaces/broker-pods/:brokerName/:podName"
       ],
       "component": { "$codeRef": "BrokerDetailsPage" }
     }

--- a/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
+++ b/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
@@ -76,5 +76,7 @@
   "last_2_weeks": "Last 2 weeks",
   "all_metrics": "All Metrics",
   "memory_usage_metrics": "Memory Usage Metrics",
-  "cpu_usage_metrics": "CPU Usage Metrics"
+  "cpu_usage_metrics": "CPU Usage Metrics",
+  "pods": "Pods",
+  "/": "/"
 }

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
       "BrokersPage": "./brokers/view-brokers",
       "AddBrokerPage": "./brokers/add-broker",
       "UpdateBrokerPage": "./brokers/update-broker",
+      "PodsListPage": "./brokers/broker-pods",
       "BrokerDetailsPage": "./brokers/broker-details"
     },
     "dependencies": {

--- a/src/brokers/broker-pods/PodsList.container.tsx
+++ b/src/brokers/broker-pods/PodsList.container.tsx
@@ -1,0 +1,94 @@
+import { FC, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import {
+  K8sResourceCommon,
+  k8sGet,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AMQBrokerModel, K8sResourceKind } from '../../utils';
+import { useTranslation } from '../../i18n';
+import { PodsList } from './components/PodList';
+import { BrokerDetailsBreadcrumb } from '../../shared-components/BrokerDetailsBreadcrumb';
+import {
+  PageSection,
+  PageSectionVariants,
+  Title,
+} from '@patternfly/react-core';
+
+const PodsContainer: FC = () => {
+  //states
+  const { t } = useTranslation();
+  const { ns: namespace, name } = useParams<{ ns?: string; name?: string }>();
+  const [brokerPods, setBrokerPods] = useState<K8sResourceKind[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [pods, loaded, loadError] = useK8sWatchResource<K8sResourceCommon[]>({
+    groupVersionKind: {
+      version: 'v1',
+      kind: 'Pod',
+    },
+    isList: true,
+    namespaced: true,
+  });
+
+  const filterBrokerPods = (pods: K8sResourceCommon[], brokerName: string) => {
+    return pods.filter((pod) =>
+      pod.metadata?.ownerReferences?.some(
+        (ref) => ref.name.startsWith(brokerName) && ref.kind === 'StatefulSet',
+      ),
+    );
+  };
+
+  useEffect(() => {
+    if (loaded && !loadError) {
+      setLoading(false);
+      const filteredPods = filterBrokerPods(pods, name);
+      setBrokerPods(filteredPods);
+    }
+  }, [pods, name, loaded, loadError]);
+
+  useEffect(() => {
+    k8sGetBroker();
+  }, [namespace, name]);
+
+  const k8sGetBroker = () => {
+    setLoading(true);
+    k8sGet({ model: AMQBrokerModel, name, ns: namespace })
+      .then((brokerPods: K8sResourceKind) => {
+        setBrokerPods([brokerPods]);
+      })
+      .catch((e) => {
+        console.error(e);
+        console.error('Pods not found');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  return (
+    <>
+      <PageSection
+        variant={PageSectionVariants.light}
+        padding={{ default: 'noPadding' }}
+        className="pf-c-page__main-tabs"
+      >
+        <div className="pf-u-mt-md pf-u-ml-md pf-u-mb-md">
+          <BrokerDetailsBreadcrumb name={name} namespace={namespace} />
+          <Title headingLevel="h2">
+            {t('broker')} {name}
+          </Title>
+        </div>
+        {!loading && brokerPods.length > 0 && (
+          <PodsList
+            brokerPods={brokerPods}
+            loadError={loadError}
+            loaded={!loading}
+            brokerName={name}
+          />
+        )}
+      </PageSection>
+    </>
+  );
+};
+
+export default PodsContainer;

--- a/src/brokers/broker-pods/components/PodList.tsx
+++ b/src/brokers/broker-pods/components/PodList.tsx
@@ -1,0 +1,109 @@
+import { FC } from 'react';
+import {
+  ListPageHeader,
+  ListPageBody,
+  VirtualizedTable,
+  useListPageFilter,
+  ListPageFilter,
+  TableColumn,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { useTranslation } from '../../../i18n';
+import { K8sResourceCommon } from '../../../utils';
+import { PodRow } from './PodRow';
+
+type PodsTableProps = {
+  data: K8sResourceCommon[];
+  unfilteredData: K8sResourceCommon[];
+  loaded: boolean;
+  loadError: any;
+  brokerName: string;
+};
+
+const PodsTable: FC<PodsTableProps> = ({
+  data,
+  unfilteredData,
+  loaded,
+  loadError,
+  brokerName,
+}) => {
+  const columns: TableColumn<K8sResourceCommon>[] = [
+    {
+      title: 'Name',
+      id: 'name',
+    },
+    {
+      title: 'Status',
+      id: 'status',
+    },
+    {
+      title: 'Ready',
+      id: 'ready',
+    },
+    {
+      title: 'Restarts',
+      id: 'restarts',
+    },
+    {
+      title: 'Created',
+      id: 'created',
+    },
+  ];
+
+  return (
+    <VirtualizedTable<K8sResourceCommon>
+      data={data}
+      unfilteredData={unfilteredData}
+      loaded={loaded}
+      loadError={loadError}
+      columns={columns}
+      Row={({ obj, activeColumnIDs, rowData }) => (
+        <PodRow
+          obj={obj}
+          rowData={rowData}
+          activeColumnIDs={activeColumnIDs}
+          columns={columns}
+          brokerName={brokerName}
+        />
+      )}
+    />
+  );
+};
+
+export type PodsListProps = {
+  brokerPods: K8sResourceCommon[];
+  loaded: boolean;
+  loadError: any;
+  brokerName: string;
+};
+
+const PodsList: FC<PodsListProps> = ({
+  brokerPods,
+  loaded,
+  loadError,
+  brokerName,
+}) => {
+  const { t } = useTranslation();
+  const [data, filteredData, onFilterChange] = useListPageFilter(brokerPods);
+
+  return (
+    <>
+      <ListPageHeader title={t('pods')} />
+      <ListPageBody>
+        <ListPageFilter
+          data={data}
+          loaded={loaded}
+          onFilterChange={onFilterChange}
+        />
+        <PodsTable
+          data={filteredData}
+          unfilteredData={data}
+          loaded={loaded}
+          loadError={loadError}
+          brokerName={brokerName}
+        />
+      </ListPageBody>
+    </>
+  );
+};
+
+export { PodsList };

--- a/src/brokers/broker-pods/components/PodRow.tsx
+++ b/src/brokers/broker-pods/components/PodRow.tsx
@@ -1,0 +1,59 @@
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  RowProps,
+  TableData,
+  TableColumn,
+  Timestamp,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { K8sResourceCommon } from '../../../utils';
+
+export type PodRowProps = RowProps<K8sResourceCommon> & {
+  columns: TableColumn<K8sResourceCommon>[];
+  brokerName: string;
+};
+
+export const PodRow: FC<PodRowProps> = ({
+  obj,
+  activeColumnIDs,
+  columns,
+  brokerName,
+}) => {
+  const {
+    metadata: { name, namespace, creationTimestamp },
+    status,
+  } = obj;
+
+  const readyCount = status?.containerStatuses
+    ? status.containerStatuses.filter((container: any) => container.ready)
+        .length
+    : 0;
+  const totalCount = status?.containerStatuses?.length || 0;
+  const podReadiness = `${readyCount}/${totalCount}`;
+
+  const restarts = status?.containerStatuses
+    ? status.containerStatuses[0]?.restartCount || 0
+    : 0;
+
+  return (
+    <>
+      <TableData id={columns[0].id} activeColumnIDs={activeColumnIDs}>
+        <Link to={`/ns/${namespace}/broker-pods/${brokerName}/${name}`}>
+          {name}
+        </Link>
+      </TableData>
+      <TableData id={columns[1].id} activeColumnIDs={activeColumnIDs}>
+        {status?.phase || '-'}
+      </TableData>
+      <TableData id={columns[2].id} activeColumnIDs={activeColumnIDs}>
+        {podReadiness}
+      </TableData>
+      <TableData id={columns[3].id} activeColumnIDs={activeColumnIDs}>
+        {restarts}
+      </TableData>
+      <TableData id={columns[4].id} activeColumnIDs={activeColumnIDs}>
+        <Timestamp timestamp={creationTimestamp} />
+      </TableData>
+    </>
+  );
+};

--- a/src/brokers/broker-pods/index.ts
+++ b/src/brokers/broker-pods/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PodsList.container';

--- a/src/utils/api-server.tsx
+++ b/src/utils/api-server.tsx
@@ -29,7 +29,7 @@ export async function LoginJolokia(
   route: K8sResourceKind,
   apiHost: string,
   apiPort: string,
-  ordinal?: number,
+  ordinal: number,
 ): Promise<[boolean, string]> {
   let jolokiaHost: string;
   let jolokiaPort: string;
@@ -119,13 +119,10 @@ function getProxyUrl(): string {
 
 type JolokiaTestPanelType = {
   broker: K8sResourceKind;
-  ordinal?: number;
+  ordinal: number;
 };
 
-const JolokiaTestPanel: FC<JolokiaTestPanelType> = ({
-  broker,
-  ordinal = 0,
-}) => {
+const JolokiaTestPanel: FC<JolokiaTestPanelType> = ({ broker, ordinal }) => {
   const [testUrl, setTestUrl] = useState<string>('');
   const [jolokiaTestResult, setJolokiaTestResult] = useState('Result:');
   const [requestError, setRequestError] = useState(false);
@@ -306,7 +303,7 @@ export type LoginState = 'none' | 'session' | 'ongoing' | 'fail' | 'ok';
 export const useJolokiaLogin = (
   brokerDetail: K8sResourceKind,
   brokerRoutes: K8sResourceKind[],
-  ordinal = 0,
+  ordinal: number,
 ): [string, LoginState] => {
   const [token, setToken] = useState<string>('');
   const [loginState, setLoginState] = useState<LoginState>('none');
@@ -379,7 +376,7 @@ export const useJolokiaLogin = (
         }
       },
     );
-  }, [brokerDetail, brokerRoutes, loginState]);
+  }, [brokerDetail, brokerRoutes, loginState, ordinal]);
   return [token, loginState];
 };
 


### PR DESCRIPTION
Designed brokers pods page to list set of pods created within specific broker. 

Pods List Page:
![Screenshot from 2024-05-02 21-49-33](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/99248895/186d3f40-6499-4ea4-8722-ba7f3cb21adb)

Broker Details Page:
![Screenshot from 2024-05-06 14-36-10](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/99248895/ce8471ee-cf6c-46b3-8cd3-d7a1193d264f)

