### PR TITLE
api-server: fix undefined access

### DIFF
--- a/src/utils/api-server.tsx
+++ b/src/utils/api-server.tsx
@@ -262,7 +262,7 @@ const getJolokiaLoginParameters = (
   if (brokerRoutes?.length === 0 && process.env.NODE_ENV !== 'production') {
     return requestBody;
   }
-  if (!broker.spec) {
+  if (!broker.spec || !broker.spec['console']) {
     return requestBody;
   }
 


### PR DESCRIPTION
When a broker with the default yaml is created, it doesn't have a `spec.console` section, and that was leading to a crash of the UX.

To reproduce the issue, create a broker wit the following spec:

```
apiVersion: broker.amq.io/v1beta1
kind: ActiveMQArtemis
metadata:
  name: default
  namespace: default
spec:
  deploymentPlan:
    image: placeholder
    requireLogin: false
    size: 1
```

Before the patch it should crash and after the patch it should work fine.