### PR TITLE
WIP: [#150] create a tls broker form

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -20,6 +20,17 @@
     "properties": {
       "exact": true,
       "path": [
+        "/k8s/ns/:ns/add-tls-broker",
+        "/k8s/all-namespaces/add-tls-broker"
+      ],
+      "component": { "$codeRef": "AddTlsBrokerPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": [
         "/k8s/ns/:ns/edit-broker/:name",
         "/k8s/all-namespaces/edit-broker/:name"
       ],

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "exposedModules": {
       "BrokersPage": "./brokers/view-brokers",
       "AddBrokerPage": "./brokers/add-broker",
+      "AddTlsBrokerPage": "./brokers/add-tls-broker",
       "UpdateBrokerPage": "./brokers/update-broker",
       "PodsListPage": "./brokers/broker-pods",
       "BrokerDetailsPage": "./brokers/broker-details"

--- a/src/brokers/add-tls-broker/AddTlsBroker.component.tsx
+++ b/src/brokers/add-tls-broker/AddTlsBroker.component.tsx
@@ -1,0 +1,211 @@
+import { FC, useReducer, useState } from 'react';
+import { AlertVariant, Divider } from '@patternfly/react-core';
+import { YamlEditorView, EditorToggle, FormView } from './components';
+import { K8sResourceCommon as ArtemisCR } from '../../utils';
+
+type AddTlsBrokerProps = {
+  namespace: string;
+  isEditWorkFlow?: boolean;
+  notification: { title: string; variant: AlertVariant };
+  createBroker: (data?: ArtemisCR) => void;
+};
+
+export enum ArtemisReducerFields {
+  ALL,
+  brokerName,
+  acceptorName,
+  acceptorPort,
+  ingressDomain,
+  issuer,
+}
+
+export type ArtemisReducerAction = {
+  field: ArtemisReducerFields;
+  value: string | number | ArtemisCR;
+};
+
+const artemisCrReducer: React.Reducer<ArtemisCR, ArtemisReducerAction> = (
+  prevCr,
+  action,
+) => {
+  const cr = { ...prevCr };
+  const createSpec = (cr: ArtemisCR) => {
+    if (!cr.spec) {
+      cr.spec = {};
+    }
+  };
+  const createAcceptor = (cr: ArtemisCR) => {
+    createSpec(cr);
+    if (!cr.spec.acceptors) {
+      cr.spec.acceptors = [
+        {
+          sslEnabled: true,
+          expose: true,
+          exposeMode: 'ingress',
+          ingressHost:
+            'ing.$(ITEM_NAME).$(CR_NAME)-$(BROKER_ORDINAL).$(CR_NAMESPACE).$(INGRESS_DOMAIN)',
+        },
+      ];
+    }
+  };
+  const createResourceTemplate = (cr: ArtemisCR) => {
+    createSpec(cr);
+    if (!cr.spec.resourceTemplates) {
+      cr.spec.resourceTemplates = [{}];
+    }
+    if (!cr.spec.resourceTemplates[0].annotations) {
+      cr.spec.resourceTemplates[0].annotations = {};
+    }
+  };
+  const createResourceTemplatePatch = (cr: ArtemisCR) => {
+    createResourceTemplate(cr);
+    if (!cr.spec.resourceTemplates[0].patch) {
+      cr.spec.resourceTemplates[0].patch = {
+        kind: 'Ingress',
+      };
+    }
+    if (!cr.spec.resourceTemplates[0].patch.spec) {
+      cr.spec.resourceTemplates[0].patch.spec = {};
+    }
+    if (!cr.spec.resourceTemplates[0].patch.spec.tls) {
+      cr.spec.resourceTemplates[0].patch.spec.tls = [{}];
+    }
+  };
+  const createResourceTemplateSelector = (cr: ArtemisCR) => {
+    createResourceTemplate(cr);
+    if (!cr.spec.resourceTemplates[0].selector) {
+      cr.spec.resourceTemplates[0].selector = {
+        kind: 'Ingress',
+      };
+    }
+  };
+
+  // set the individual fields
+  switch (action.field) {
+    case ArtemisReducerFields.ALL: // escape hatch to set the entire CR
+      if (
+        typeof action.value === 'string' ||
+        typeof action.value === 'number'
+      ) {
+        throw Error('action: ' + action.field + ' needs arg of type ArtemisCR');
+      }
+      return action.value;
+    case ArtemisReducerFields.brokerName:
+      if (typeof action.value !== 'string') {
+        throw Error('action: ' + action.field + ' needs arg of type string');
+      }
+      cr.metadata.name = action.value;
+      break;
+    case ArtemisReducerFields.acceptorName:
+      if (typeof action.value !== 'string') {
+        throw Error('action: ' + action.field + ' needs arg of type string');
+      }
+      createAcceptor(cr);
+      cr.spec.acceptors[0].name = action.value;
+      break;
+    case ArtemisReducerFields.acceptorPort:
+      if (typeof action.value !== 'number') {
+        throw Error('action: ' + action.field + ' needs arg of type number');
+      }
+      createAcceptor(cr);
+      cr.spec.acceptors[0].port = action.value;
+      break;
+    case ArtemisReducerFields.ingressDomain:
+      if (typeof action.value !== 'string') {
+        throw Error('action: ' + action.field + ' needs arg of type string');
+      }
+      createSpec(cr);
+      cr.spec.ingressDomain = action.value;
+      break;
+    case ArtemisReducerFields.issuer:
+      if (typeof action.value !== 'string') {
+        throw Error('action: ' + action.field + ' needs arg of type string');
+      }
+      createResourceTemplate(cr);
+      cr.spec.resourceTemplates[0].annotations['cert-manager.io/issuer'] =
+        action.value;
+      break;
+    default:
+      throw Error('Unknown action: ' + action);
+  }
+
+  // update the composed fields
+  if (cr.spec?.acceptors && cr.spec.acceptors[0].name) {
+    const secretName =
+      cr.metadata.name + '-' + cr.spec.acceptors[0].name + '-0-svc-ing-ptls';
+    cr.spec.acceptors[0].sslSecret = secretName;
+
+    createResourceTemplatePatch(cr);
+    cr.spec.resourceTemplates[0].patch.spec.tls[0].secretName = secretName;
+    if (cr.spec.ingressDomain) {
+      cr.spec.resourceTemplates[0].patch.spec.tls[0].hosts = [
+        'ing.' +
+          cr.spec.acceptors[0].name +
+          '.' +
+          cr.metadata.name +
+          '-0.' +
+          cr.metadata.namespace +
+          '.' +
+          cr.spec.ingressDomain,
+      ];
+    }
+
+    createResourceTemplateSelector(cr);
+    cr.spec.resourceTemplates[0].selector.name =
+      cr.metadata.name + '-' + cr.spec.acceptors[0].name + '-0-' + 'svc-ing';
+  }
+  return cr;
+};
+
+const AddTlsBroker: FC<AddTlsBrokerProps> = ({
+  namespace,
+  createBroker,
+  notification,
+}) => {
+  const [isFormEditor, setIsFormEditor] = useState<boolean>(true);
+  const [cr, dispatch] = useReducer(artemisCrReducer, {
+    apiVersion: 'broker.amq.io/v1beta1',
+    kind: 'ActiveMQArtemis',
+    metadata: {
+      name: 'default',
+      namespace,
+    },
+    spec: {
+      ingressDomain: 'apps-crc.testing',
+      deploymentPlan: {
+        image: 'placeholder',
+        requireLogin: false,
+        size: 1,
+      },
+    },
+  });
+
+  return (
+    <>
+      <EditorToggle
+        isFormEditor={isFormEditor}
+        switchFunction={() => setIsFormEditor(!isFormEditor)}
+      />
+      <Divider />
+      {isFormEditor && (
+        <FormView
+          namespace={namespace}
+          formValues={cr}
+          dispatch={dispatch}
+          onCreateBroker={createBroker}
+          serverNotification={notification}
+        />
+      )}
+      {!isFormEditor && (
+        <YamlEditorView
+          namespace={namespace}
+          cr={cr}
+          dispatch={dispatch}
+          serverNotification={notification}
+        />
+      )}
+    </>
+  );
+};
+
+export default AddTlsBroker;

--- a/src/brokers/add-tls-broker/AddTlsBroker.container.tsx
+++ b/src/brokers/add-tls-broker/AddTlsBroker.container.tsx
@@ -1,0 +1,41 @@
+import { FC, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+import { k8sCreate } from '@openshift-console/dynamic-plugin-sdk';
+import { AlertVariant } from '@patternfly/react-core';
+import { AMQBrokerModel, K8sResourceCommon as ArtemisCR } from '../../utils';
+import AddTlsBroker from './AddTlsBroker.component';
+
+const AddTlsBrokerPage: FC = () => {
+  const history = useHistory();
+  const { ns: namespace } = useParams<{ ns?: string }>();
+
+  const defaultNotification = { title: '', variant: AlertVariant.default };
+
+  const [notification, setNotification] = useState(defaultNotification);
+
+  const handleRedirect = () => {
+    history.push('/k8s/all-namespaces/brokers');
+  };
+
+  const k8sCreateBroker = (content: ArtemisCR) => {
+    k8sCreate({ model: AMQBrokerModel, data: content })
+      .then(() => {
+        setNotification(defaultNotification);
+        handleRedirect();
+      })
+      .catch((e) => {
+        setNotification({ title: e.message, variant: AlertVariant.danger });
+        console.error(e);
+      });
+  };
+
+  return (
+    <AddTlsBroker
+      namespace={namespace}
+      notification={notification}
+      createBroker={k8sCreateBroker}
+    />
+  );
+};
+
+export default AddTlsBrokerPage;

--- a/src/brokers/add-tls-broker/components/AddBrokerForm/FormView.tsx
+++ b/src/brokers/add-tls-broker/components/AddBrokerForm/FormView.tsx
@@ -1,0 +1,323 @@
+import { FC, useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  Alert,
+  Button,
+  ButtonVariant,
+  ActionGroup,
+  AlertGroup,
+  AlertVariant,
+  ValidatedOptions,
+  Spinner,
+  SelectOption,
+  Select,
+  SelectVariant,
+} from '@patternfly/react-core';
+import { useTranslation } from '../../../../i18n';
+import { K8sResourceCommon as ArtemisCR } from '../../../../utils';
+import {
+  K8sResourceCommon,
+  RedExclamationCircleIcon,
+  useK8sWatchResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { t } from 'i18next';
+import {
+  ArtemisReducerAction,
+  ArtemisReducerFields,
+} from '../../AddTlsBroker.component';
+
+type SelectIssuerProps = {
+  namespace: string;
+  selectedIssuer: string;
+  setSelectedIssuer: (issuerName: string) => void;
+};
+
+export const SelectIssuer: FC<SelectIssuerProps> = ({
+  namespace,
+  selectedIssuer,
+  setSelectedIssuer,
+}) => {
+  const [issuers, loaded, loadError] = useK8sWatchResource<K8sResourceCommon[]>(
+    {
+      groupVersionKind: {
+        group: 'cert-manager.io',
+        version: 'v1',
+        kind: 'Issuer',
+      },
+      isList: true,
+      namespace: namespace,
+    },
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  if (!loaded) {
+    return <Spinner size="lg" />;
+  }
+  if (loadError) {
+    return (
+      <>
+        {t('cant-fetch-issuers')}
+        <RedExclamationCircleIcon />
+      </>
+    );
+  }
+  const options = issuers.map((issuer) => (
+    <SelectOption key={issuer.metadata.name} value={issuer.metadata.name} />
+  ));
+
+  const onSelect = (_event: any, selection: string, isPlaceholder: any) => {
+    if (isPlaceholder) clearSelection();
+    else {
+      setSelectedIssuer(selection);
+      setIsOpen(false);
+    }
+  };
+
+  const clearSelection = () => {
+    setSelectedIssuer('');
+    setIsOpen(false);
+  };
+
+  const filterMatchingOptions = (_: any, value: string) => {
+    if (!value) {
+      return options;
+    }
+
+    const input = new RegExp(value, 'i');
+    return options.filter((child) => input.test(child.props.value));
+  };
+
+  const titleId = 'typeahead-select-issuer';
+  return (
+    <div>
+      <span id={titleId} hidden>
+        Select a state
+      </span>
+      <Select
+        variant={SelectVariant.typeahead}
+        typeAheadAriaLabel="Select an issuer"
+        onToggle={() => setIsOpen(!isOpen)}
+        onSelect={onSelect}
+        onClear={clearSelection}
+        onFilter={filterMatchingOptions}
+        selections={selectedIssuer}
+        isOpen={isOpen}
+        aria-labelledby={titleId}
+        placeholderText="Select an issuer"
+      >
+        {options}
+      </Select>
+    </div>
+  );
+};
+
+type FormViewProps = {
+  namespace: string;
+  formValues: ArtemisCR;
+  dispatch: React.Dispatch<ArtemisReducerAction>;
+  onCreateBroker: (formValues: ArtemisCR) => void;
+  serverNotification: {
+    title: string;
+    variant: AlertVariant;
+  };
+};
+
+export const FormView: FC<FormViewProps> = ({
+  namespace,
+  formValues: cr,
+  dispatch,
+  onCreateBroker,
+  serverNotification: serverNotification,
+}) => {
+  const [prevServerNotif, setPrevServerNotif] = useState(serverNotification);
+  const [notification, setNotification] = useState(serverNotification);
+  if (serverNotification !== prevServerNotif) {
+    setNotification(serverNotification);
+    setPrevServerNotif(serverNotification);
+  }
+
+  const { t } = useTranslation();
+  const history = useHistory();
+
+  const selectedIssuer =
+    cr.spec?.resourceTemplates && cr.spec.resourceTemplates[0].annotations
+      ? cr.spec.resourceTemplates[0].annotations['cert-manager.io/issuer']
+      : '';
+
+  const validateGenericName = (name: string) => {
+    const regex =
+      /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/i;
+    return regex.test(name);
+  };
+
+  const onSubmit = () => {
+    if (
+      validateGenericName(cr.metadata.name) &&
+      validateGenericName(
+        cr.spec?.acceptors && cr.spec.acceptors[0]
+          ? cr.spec.acceptors[0].name
+          : '',
+      )
+    ) {
+      setNotification({ title: '', variant: AlertVariant.success });
+      onCreateBroker(cr);
+    } else {
+      setNotification({
+        title: t('form_view_validation_info'),
+        variant: AlertVariant.danger,
+      });
+    }
+  };
+
+  const onCancel = () => {
+    history.push('/k8s/all-namespaces/brokers');
+  };
+
+  return (
+    <Form
+      isWidthLimited
+      className="pf-u-mx-md"
+      maxWidth="50%"
+      onSubmit={(e: React.FormEvent<HTMLFormElement>): void => {
+        e.preventDefault();
+      }}
+    >
+      <Alert
+        variant="info"
+        isInline
+        title={t('info_alert')}
+        className="pf-u-mt-md"
+      />
+      {notification.title && (
+        <AlertGroup>
+          <Alert
+            data-test="add-broker-notification-form-view"
+            title={notification.title}
+            variant={notification.variant}
+            isInline
+            actionClose
+          />
+        </AlertGroup>
+      )}
+
+      <FormGroup label={t('domain')} isRequired fieldId="domain">
+        <TextInput
+          isRequired
+          type="text"
+          id="domain"
+          name="domain"
+          value={cr.spec?.ingressDomain}
+          validated={
+            validateGenericName(cr.spec?.ingressDomain)
+              ? ValidatedOptions.success
+              : ValidatedOptions.error
+          }
+          onChange={(value) =>
+            dispatch({
+              field: ArtemisReducerFields.ingressDomain,
+              value: value,
+            })
+          }
+        />
+      </FormGroup>
+      <FormGroup label={t('name')} isRequired fieldId="name">
+        <TextInput
+          isRequired
+          type="text"
+          id="name"
+          name="name"
+          value={cr.metadata.name}
+          validated={
+            validateGenericName(cr.metadata.name)
+              ? ValidatedOptions.success
+              : ValidatedOptions.error
+          }
+          onChange={(value) =>
+            dispatch({
+              field: ArtemisReducerFields.brokerName,
+              value: value,
+            })
+          }
+        />
+      </FormGroup>
+      <FormGroup label={t('issuer')} isRequired fieldId="issuer">
+        <SelectIssuer
+          namespace={namespace}
+          selectedIssuer={selectedIssuer}
+          setSelectedIssuer={(value) =>
+            dispatch({
+              field: ArtemisReducerFields.issuer,
+              value: value,
+            })
+          }
+        />
+      </FormGroup>
+      <FormGroup label={t('acceptor')} isRequired fieldId="acceptor">
+        <TextInput
+          isRequired
+          type="text"
+          id="acceptor_name"
+          name="acceptor_name"
+          value={
+            cr.spec?.acceptors && cr.spec.acceptors[0]
+              ? cr.spec.acceptors[0].name
+              : ''
+          }
+          validated={
+            validateGenericName(
+              cr.spec?.acceptors && cr.spec.acceptors[0]
+                ? cr.spec.acceptors[0].name
+                : '',
+            )
+              ? ValidatedOptions.success
+              : ValidatedOptions.error
+          }
+          onChange={(value) =>
+            dispatch({
+              field: ArtemisReducerFields.acceptorName,
+              value: value,
+            })
+          }
+        />
+        <TextInput
+          isRequired
+          type="number"
+          id="acceptor_port"
+          name="acceptor_port"
+          value={
+            cr.spec?.acceptors && cr.spec.acceptors[0]
+              ? cr.spec.acceptors[0].port
+              : ''
+          }
+          validated={
+            typeof (cr.spec?.acceptors && cr.spec.acceptors[0]
+              ? cr.spec.acceptors[0].port
+              : '') === 'number'
+              ? ValidatedOptions.success
+              : ValidatedOptions.error
+          }
+          onChange={(value) => {
+            dispatch({
+              field: ArtemisReducerFields.acceptorPort,
+              value: Number(value),
+            });
+          }}
+        />
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          variant={ButtonVariant.primary}
+          type="submit"
+          onClick={onSubmit}
+        >
+          {t('create')}
+        </Button>
+        <Button variant={ButtonVariant.secondary} onClick={onCancel}>
+          {t('cancel')}
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};

--- a/src/brokers/add-tls-broker/components/AddBrokerForm/YamlEditorView.stories.tsx
+++ b/src/brokers/add-tls-broker/components/AddBrokerForm/YamlEditorView.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { YamlEditorView } from './YamlEditorView';
+
+export default {
+  title: 'Components/AddBrokerForm',
+  component: YamlEditorView,
+  argTypes: {
+    backgroundColor: { control: 'color' },
+  },
+} as ComponentMeta<typeof YamlEditorView>;
+
+const Template: ComponentStory<typeof YamlEditorView> = (args) => {
+  return <YamlEditorView {...args} />;
+};
+
+export const YamlEditorViewStory = Template.bind({});

--- a/src/brokers/add-tls-broker/components/AddBrokerForm/YamlEditorView.tsx
+++ b/src/brokers/add-tls-broker/components/AddBrokerForm/YamlEditorView.tsx
@@ -1,0 +1,89 @@
+import { FC, Suspense } from 'react';
+import { load } from 'js-yaml';
+import { Alert, AlertVariant, AlertGroup } from '@patternfly/react-core';
+import {
+  ResourceYAMLEditor,
+  useAccessReview,
+} from '@openshift-console/dynamic-plugin-sdk';
+import {
+  AMQBrokerModel,
+  K8sResourceCommon as ArtemisCR,
+} from '../../../../utils';
+import { Loading } from '../../../../shared-components';
+import { useTranslation } from '../../../../i18n';
+import { convertYamlToForm } from '../../../../brokers/utils';
+import {
+  ArtemisReducerAction,
+  ArtemisReducerFields,
+} from '../../AddTlsBroker.component';
+
+export type YamlEditorViewProps = {
+  namespace: string;
+  cr: ArtemisCR;
+  dispatch: React.Dispatch<ArtemisReducerAction>;
+  serverNotification: {
+    title: string;
+    variant: AlertVariant;
+  };
+};
+
+const YamlEditorView: FC<YamlEditorViewProps> = ({
+  namespace,
+  cr,
+  dispatch,
+  serverNotification,
+}) => {
+  const { t } = useTranslation();
+  const [canCreateBroker, loadingAccessReview] = useAccessReview({
+    group: AMQBrokerModel.apiGroup,
+    resource: AMQBrokerModel.plural,
+    namespace,
+    verb: 'create',
+  });
+
+  const onSave = (content: string) => {
+    dispatch({
+      field: ArtemisReducerFields.ALL,
+      value: load(content) as ArtemisCR,
+    });
+  };
+
+  if (loadingAccessReview) return <Loading />;
+
+  return (
+    <>
+      {canCreateBroker ? (
+        <>
+          {serverNotification.title && (
+            <AlertGroup>
+              <Alert
+                data-test="add-broker-notification-yaml-view"
+                title={serverNotification.title}
+                variant={serverNotification.variant}
+                isInline
+                actionClose
+                className="pf-u-mt-md pf-u-mx-md"
+              />
+            </AlertGroup>
+          )}
+          <Suspense fallback={<Loading />}>
+            <ResourceYAMLEditor
+              initialResource={convertYamlToForm(cr)}
+              header={t('create_resource')}
+              onSave={onSave}
+            />
+          </Suspense>
+        </>
+      ) : (
+        <Alert
+          variant={AlertVariant.default}
+          title={t('broker_can_not_be_created')}
+          isInline
+        >
+          {t('you_do_not_have_write_access')}
+        </Alert>
+      )}
+    </>
+  );
+};
+export { YamlEditorView };

--- a/src/brokers/add-tls-broker/components/AddBrokerForm/index.ts
+++ b/src/brokers/add-tls-broker/components/AddBrokerForm/index.ts
@@ -1,0 +1,2 @@
+export * from './YamlEditorView';
+export * from './FormView';

--- a/src/brokers/add-tls-broker/components/EditorToggle/EditorToggle.tsx
+++ b/src/brokers/add-tls-broker/components/EditorToggle/EditorToggle.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Flex, Radio } from '@patternfly/react-core';
+import { useTranslation } from '../../../../i18n';
+import { EditorType } from '../../../utils/add-broker';
+
+type EditorToggleProps = {
+  isFormEditor: boolean;
+  switchFunction?: () => void;
+};
+
+export const EditorToggle: React.FC<EditorToggleProps> = ({
+  isFormEditor,
+  switchFunction,
+}) => {
+  const { t } = useTranslation();
+  const handleChange = (
+    _checked: boolean,
+    _event: React.FormEvent<HTMLInputElement>,
+  ) => {
+    switchFunction();
+  };
+  return (
+    <div className="pf-u-mx-md pf-u-my-sm">
+      <Flex
+        spaceItems={{ default: 'spaceItemsMd' }}
+        alignItems={{ default: 'alignItemsCenter' }}
+        role="radiogroup"
+        aria-labelledby="radio-group-title-editor-toggle"
+      >
+        <label id="radio-group-title-editor-toggle">{t('configure_via')}</label>
+        <Radio
+          isChecked={isFormEditor}
+          name={EditorType.Form}
+          onChange={handleChange}
+          label={t('form_view')}
+          id={EditorType.Form}
+          value={EditorType.Form}
+        />
+        <Radio
+          isChecked={!isFormEditor}
+          name={EditorType.YAML}
+          onChange={handleChange}
+          label={t('yaml_view')}
+          id={EditorType.YAML}
+          value={EditorType.YAML}
+          data-test={`${EditorType.YAML}-view-input`}
+        />
+      </Flex>
+    </div>
+  );
+};

--- a/src/brokers/add-tls-broker/components/EditorToggle/index.ts
+++ b/src/brokers/add-tls-broker/components/EditorToggle/index.ts
@@ -1,0 +1,1 @@
+export * from './EditorToggle';

--- a/src/brokers/add-tls-broker/components/index.ts
+++ b/src/brokers/add-tls-broker/components/index.ts
@@ -1,0 +1,2 @@
+export * from './AddBrokerForm';
+export * from './EditorToggle';

--- a/src/brokers/add-tls-broker/index.ts
+++ b/src/brokers/add-tls-broker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddTlsBroker.container';

--- a/src/brokers/view-brokers/components/BrokersList/BrokersList.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokersList.tsx
@@ -106,6 +106,11 @@ const BrokersList: FC<BrokersListProps> = ({
       <ListPageHeader title={t('brokers')}>
         <ListPageCreateLink to={`/k8s/ns/${namespace || 'default'}/add-broker`}>
           {t('create_broker')}
+        </ListPageCreateLink>{' '}
+        <ListPageCreateLink
+          to={`/k8s/ns/${namespace || 'default'}/add-tls-broker`}
+        >
+          {t('create_tls_broker')}
         </ListPageCreateLink>
       </ListPageHeader>
       <ListPageBody>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,6 +2,48 @@ import { K8sResourceCommon as K8sResource } from '@openshift-console/dynamic-plu
 
 export type K8sResourceCommon = K8sResource & {
   spec?: {
+    ingressDomain?: string;
+    acceptors?: [
+      {
+        name?: string;
+        port?: number;
+        sslEnabled?: boolean;
+        expose?: boolean;
+        exposeMode?: 'ingress';
+        sslSecret?: string;
+        ingressHost?: string;
+        [key: string]: any;
+      },
+    ];
+    resourceTemplates?: [
+      {
+        selector?: {
+          kind?: 'Ingress';
+          name?: string;
+          [key: string]: any;
+        };
+        annotations?: {
+          'cert-manager.io/issuer'?: string;
+          [key: string]: any;
+        };
+        patch?: {
+          kind?: 'Ingress';
+          spec?: {
+            tls?: [
+              {
+                hosts?: string[];
+                secretName?: string;
+                [key: string]: any;
+              },
+            ];
+            [key: string]: any;
+          };
+          [key: string]: any;
+        };
+        [key: string]: any;
+      },
+    ];
+    brokerProperties?: string[];
     [key: string]: any;
   };
   status?: { [key: string]: any };


### PR DESCRIPTION
### Prerequisites

> [!WARNING]
> Only tested on a local crc for now. Make sure `apps-crc.testing` is
resolvable.

- Install CRC
- Install the OLM AMQ operator in the operatorHub
- Install the OLM cert-manager in the operatorHub

#### Manual chain of trust creation (temporary)

Deploy these CRs to have an issuer to refer to in the form:

```
kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: send-receive-root-issuer
  namespace: default
spec:
  selfSigned: {}
EOF

kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: send-receive-issuer-cert
  namespace: default
spec:
  isCA: true
  commonName: ArtemiseCloud send-receive issuer
  dnsNames:
    - issuer.demo.artemiscloud.io
  secretName: send-receive-issuer-cert-secret
  privateKey:
    algorithm: ECDSA
    size: 256
  issuerRef:
    name: send-receive-root-issuer
    kind: Issuer
EOF

kubectl apply -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: send-receive-issuer
  namespace: default
spec:
  ca:
    secretName: send-receive-issuer-cert-secret
EOF
```

### How to use it

#### Broker creation

On the brokers list page, click on `create_tls_broker` it'll open a new
page where you can fill in the required fields to create a tls enabled
broker.

- Enter the cluster domain: apps-crc.testing
- Enter a broker name: default
- Select the issuer: `send-receive-issuer`
- Enter an acceptor name: sslacceptor
- Enter an acceptor port: 62626

And then proceed to clicking on create.

#### Send and receive messages

Download the issuer's CA:
`kubectl get secrets send-receive-issuer-cert-secret -o json | jq -r '.data."tls.crt"' | base64 -d > /tmp/broker.pem`

Run the artemis binary on the ingress url:
 `./artemis check queue --name TEST --produce 10 --browse 10 --consume 10 --url 'tcp://ing.sslacceptor.default-0.default.apps-crc.testing:443?sslEnabled=true&trustStorePath=/tmp/broker.pem&trustStoreType=PEM' --verbose`

It's expected that few errors show up in the console at this point, but
these are more warnings, what counts is that the commands succeeds at
the end:
```
Checks run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.305 sec - QueueCheck
```

### A few screen caps:

#### The form:
![image](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/86971992/f7bacddd-7f7b-4d4b-be72-7358232bc218)

#### The generated yaml:
![image](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/86971992/591d53d5-7d77-4066-97d7-13a46755733a)

#### The console output when connecting an out-of-cluster client:

<details> 
<summary>

```
./artemis check queue --name TEST --produce 10 --browse 10 --consume 10 --url 'tcp://ing.sslacceptor.default-0.default.apps-crc.testing:443?sslEnabled=true&trustStorePath=/tmp/broker.pem&trustStoreType=PEM' --verbose
Checks run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.305 sec - QueueCheck
```

</summary>

```
./artemis check queue --name TEST --produce 10 --browse 10 --consume 10 --url 'tcp://ing.sslacceptor.default-0.default.apps-crc.testing:443?sslEnabled=true&trustStorePath=/tmp/broker.pem&trustStoreType=PEM' --verbose
Executing org.apache.activemq.artemis.cli.commands.check.QueueCheck check queue --name TEST --produce 10 --browse 10 --consume 10 --url tcp://ing.sslacceptor.default-0.default.apps-crc.testing:443?sslEnabled=true&trustStorePath=/tmp/broker.pem&trustStoreType=PEM --verbose 
Home::/home/tlavocat/dev/activemq-artemis/artemis-distribution/target/apache-artemis-2.34.0-SNAPSHOT-bin/apache-artemis-2.34.0-SNAPSHOT, Instance::null
Connection brokerURL = tcp://ing.sslacceptor.default-0.default.apps-crc.testing:443?sslEnabled=true&trustStorePath=/tmp/broker.pem&trustStoreType=PEM
Running QueueCheck
Checking that a producer can send 10 messages to the queue TEST ... 14:37:36.898 [pool-2-thread-1] ERROR org.apache.activemq.artemis.core.client - AMQ214016: Failed to create netty connection
java.net.UnknownHostException: default-ss-0.default-hdls-svc.default.svc.cluster.local
	at java.base/java.net.InetAddress$CachedAddresses.get(InetAddress.java:797) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1533) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1386) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1307) ~[?:?]
	at java.base/java.net.InetAddress.getByName(InetAddress.java:1257) ~[?:?]
	at io.netty.util.internal.SocketUtils$8.run(SocketUtils.java:156) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.SocketUtils$8.run(SocketUtils.java:153) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at java.base/java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at io.netty.util.internal.SocketUtils.addressByName(SocketUtils.java:153) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.DefaultNameResolver.doResolve(DefaultNameResolver.java:41) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.SimpleNameResolver.resolve(SimpleNameResolver.java:61) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.SimpleNameResolver.resolve(SimpleNameResolver.java:53) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.InetSocketAddressResolver.doResolve(InetSocketAddressResolver.java:55) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.InetSocketAddressResolver.doResolve(InetSocketAddressResolver.java:31) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.AbstractAddressResolver.resolve(AbstractAddressResolver.java:106) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap.doResolveAndConnect0(Bootstrap.java:220) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap.access$000(Bootstrap.java:47) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap$1.operationComplete(Bootstrap.java:189) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap$1.operationComplete(Bootstrap.java:175) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:625) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:105) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:84) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetSuccess(AbstractChannel.java:990) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:516) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:416) ~[netty-transport-classes-epoll-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at org.apache.activemq.artemis.utils.ActiveMQThreadFactory$1.run(ActiveMQThreadFactory.java:118) ~[artemis-commons-2.34.0-SNAPSHOT.jar:2.34.0-SNAPSHOT]
success
Checking that a consumer can browse 10 messages from the queue TEST ... 14:37:39.066 [pool-2-thread-1] ERROR org.apache.activemq.artemis.core.client - AMQ214016: Failed to create netty connection
java.net.UnknownHostException: default-ss-0.default-hdls-svc.default.svc.cluster.local
	at java.base/java.net.InetAddress$CachedAddresses.get(InetAddress.java:797) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1533) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1386) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1307) ~[?:?]
	at java.base/java.net.InetAddress.getByName(InetAddress.java:1257) ~[?:?]
	at io.netty.util.internal.SocketUtils$8.run(SocketUtils.java:156) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.SocketUtils$8.run(SocketUtils.java:153) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at java.base/java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at io.netty.util.internal.SocketUtils.addressByName(SocketUtils.java:153) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.DefaultNameResolver.doResolve(DefaultNameResolver.java:41) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.SimpleNameResolver.resolve(SimpleNameResolver.java:61) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.SimpleNameResolver.resolve(SimpleNameResolver.java:53) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.InetSocketAddressResolver.doResolve(InetSocketAddressResolver.java:55) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.InetSocketAddressResolver.doResolve(InetSocketAddressResolver.java:31) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.AbstractAddressResolver.resolve(AbstractAddressResolver.java:106) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap.doResolveAndConnect0(Bootstrap.java:220) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap.access$000(Bootstrap.java:47) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap$1.operationComplete(Bootstrap.java:189) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap$1.operationComplete(Bootstrap.java:175) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:625) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:105) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:84) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetSuccess(AbstractChannel.java:990) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:516) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:416) ~[netty-transport-classes-epoll-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at org.apache.activemq.artemis.utils.ActiveMQThreadFactory$1.run(ActiveMQThreadFactory.java:118) ~[artemis-commons-2.34.0-SNAPSHOT.jar:2.34.0-SNAPSHOT]
success
Checking that a consumer can consume 10 messages from the queue TEST ... 14:37:41.131 [pool-2-thread-1] ERROR org.apache.activemq.artemis.core.client - AMQ214016: Failed to create netty connection
java.net.UnknownHostException: default-ss-0.default-hdls-svc.default.svc.cluster.local
	at java.base/java.net.InetAddress$CachedAddresses.get(InetAddress.java:797) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName0(InetAddress.java:1533) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1386) ~[?:?]
	at java.base/java.net.InetAddress.getAllByName(InetAddress.java:1307) ~[?:?]
	at java.base/java.net.InetAddress.getByName(InetAddress.java:1257) ~[?:?]
	at io.netty.util.internal.SocketUtils$8.run(SocketUtils.java:156) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.SocketUtils$8.run(SocketUtils.java:153) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at java.base/java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at io.netty.util.internal.SocketUtils.addressByName(SocketUtils.java:153) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.DefaultNameResolver.doResolve(DefaultNameResolver.java:41) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.SimpleNameResolver.resolve(SimpleNameResolver.java:61) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.SimpleNameResolver.resolve(SimpleNameResolver.java:53) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.InetSocketAddressResolver.doResolve(InetSocketAddressResolver.java:55) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.InetSocketAddressResolver.doResolve(InetSocketAddressResolver.java:31) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.resolver.AbstractAddressResolver.resolve(AbstractAddressResolver.java:106) ~[netty-resolver-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap.doResolveAndConnect0(Bootstrap.java:220) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap.access$000(Bootstrap.java:47) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap$1.operationComplete(Bootstrap.java:189) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.bootstrap.Bootstrap$1.operationComplete(Bootstrap.java:175) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListener0(DefaultPromise.java:590) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListenersNow(DefaultPromise.java:557) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:492) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setValue0(DefaultPromise.java:636) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.setSuccess0(DefaultPromise.java:625) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.DefaultPromise.trySuccess(DefaultPromise.java:105) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.DefaultChannelPromise.trySuccess(DefaultChannelPromise.java:84) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.safeSetSuccess(AbstractChannel.java:990) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:516) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486) ~[netty-transport-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:416) ~[netty-transport-classes-epoll-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.108.Final.jar:4.1.108.Final]
	at org.apache.activemq.artemis.utils.ActiveMQThreadFactory$1.run(ActiveMQThreadFactory.java:118) ~[artemis-commons-2.34.0-SNAPSHOT.jar:2.34.0-SNAPSHOT]
success
Checks run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.305 sec - QueueCheck
```

</details>

#### There are still a couple of things to fix in the deployment:
![image](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/86971992/1cdf6799-70fb-4f23-9b0f-26fc6100a5a4)

```
status:
  conditions:
    - lastTransitionTime: '2024-05-30T12:36:31Z'
      message: ''
      observedGeneration: 1
      reason: ValidationSucceded
      status: 'True'
      type: Valid
    - lastTransitionTime: '2024-05-30T12:36:32Z'
      message: no available brokers from deployed condition
      reason: UnableToRetrieveStatus
      status: Unknown
      type: BrokerPropertiesApplied
    - lastTransitionTime: '2024-05-30T12:36:32Z'
      message: '["failed to create new *v1.Ingress, ingresses.networking.k8s.io \"default-sslacceptor-0-svc-ing\" already exists"]'
      reason: ResourceError
      status: 'False'
      type: Deployed
    - lastTransitionTime: '2024-05-30T12:36:32Z'
      message: Some conditions are not met
      reason: WaitingForAllConditions
      status: 'False'
      type: Ready
```



### TODOlist of the PR:

- [x] Rewrite using `useReducer` instead of `useState`
- [ ] Understand why the status isn't OK
- [x] Make all the necessaery fields customizable (clusterDomain, port)
- [ ] Add buttons to download the apprioriate PEM file
- [ ] Add instruction to download cert-manager if missing
- [ ] Add a buttion to create cert manager certs
