### PR TITLE
Use patternfly components for the broker form

### DIFF
--- a/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
+++ b/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
@@ -120,13 +120,17 @@
   "select_acceptor": "Acceptor",
   "select_an_acceptor": "Select an acceptor",
   "select_acceptor_help": "This annotation must be linked to an acceptor. Acceptors can get created in the 'Acceptors' menu.",
-  "Add an annotation": "Add an annotation",
+  "Add an annotation": "Select a preset",
   "annotation modal helper": "Select an issuer to generate a cert-manager annotation.",
   "Annotate_an_acceptor_with_an_issuer": "Cert-Manager issuer & Ingress exposure",
   "create_new_chain_of_trust": "Create a new chain of trust",
   "new_chain_of_trust": "Name of the issuer",
   "new_chain_of_trust_helper": "Clicking on create will trigger the creation of 3 elements, a root issuer, a certificate signed by the root issuer, and an issuer using the certificate. The name of the issuer will correspond to the later.",
-  "select_annotation": "Choose an annotation",
-  "select_annotation_help": "Choose an annotation in the available cards. A disabled card means that the annotation is already applied onto the current acceptor.",
-  "cert_manager_annotation": "Cert-Manager issuer & Ingress exposure"
+  "select_annotation": "Choose a preset",
+  "select_annotation_help": "Choose a preset in the available cards. A disabled card means that the preset is already applied onto the current acceptor.",
+  "cert_manager_annotation": "Cert-Manager issuer & Ingress exposure",
+  "preset_warning": "This setting is linked to a preset, updating the value will result in the preset to be removed",
+  "preset_caution": "This setting is linked to a preset, proceed with caution",
+  "ingressHost": "Ingress Host",
+  "select_expose_mode": "Expose Mode"
 }

--- a/src/brokers/utils/add-broker.ts
+++ b/src/brokers/utils/add-broker.ts
@@ -1475,11 +1475,11 @@ const updateConfigSSLEnabled = (
     if (acceptor) {
       acceptor.sslEnabled = isSSLEnabled;
       if (!acceptor.sslEnabled) {
+        clearAcceptorCertManagerConfig(brokerModel, acceptor.name);
         delete acceptor.sslSecret;
         delete acceptor.trustSecret;
         delete acceptor.wantClientAuth;
         delete acceptor.needClientAuth;
-        clearAcceptorCertManagerConfig(brokerModel, acceptor.name);
       }
     }
   }

--- a/src/brokers/utils/add-broker.ts
+++ b/src/brokers/utils/add-broker.ts
@@ -1804,7 +1804,7 @@ export const getConfigOtherParams = (
 export const listConfigs = (
   configType: ConfigType,
   brokerModel: ArtemisCR,
-  resultType?: string,
+  resultType?: 'set' | 'list',
 ): { name: string }[] | Set<string> => {
   const acceptors = new Set<string>();
   if (configType === ConfigType.connectors) {

--- a/src/configuration/acceptors-annotations.tsx
+++ b/src/configuration/acceptors-annotations.tsx
@@ -25,7 +25,7 @@ import {
 import { useTranslation } from '../i18n';
 import { Acceptor, ResourceTemplate } from '../utils';
 import { SelectIssuerDrawer } from './cert-manager';
-import { TrashIcon } from '@patternfly/react-icons';
+import { ConfirmDeleteModal } from './confirmation-modal';
 
 type WithAcceptorProps = {
   acceptor?: Acceptor;
@@ -201,19 +201,16 @@ const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
           }}
           titleDescription="Configuration items for the preset"
           actions={
-            <Button
-              variant="plain"
-              aria-label="Remove"
-              onClick={() =>
+            <ConfirmDeleteModal
+              subject="preset"
+              action={() =>
                 dispatch({
                   operation:
                     ArtemisReducerOperations.deletePEMGenerationForAcceptor,
                   payload: acceptor.name,
                 })
               }
-            >
-              <TrashIcon />
-            </Button>
+            />
           }
         />
       }

--- a/src/configuration/acceptors-annotations.tsx
+++ b/src/configuration/acceptors-annotations.tsx
@@ -3,22 +3,15 @@ import {
   Card,
   CardBody,
   CardTitle,
-  Dropdown,
-  DropdownItem,
-  ExpandableSection,
   Form,
   FormFieldGroup,
+  FormFieldGroupExpandable,
   FormFieldGroupHeader,
   FormGroup,
-  KebabToggle,
-  List,
-  ListItem,
   Modal,
   ModalVariant,
   SimpleList,
   SimpleListGroup,
-  Split,
-  SplitItem,
 } from '@patternfly/react-core';
 import { CSSProperties, FC, useContext, useState } from 'react';
 import {
@@ -31,6 +24,7 @@ import {
 import { useTranslation } from '../i18n';
 import { Acceptor, ResourceTemplate } from '../utils';
 import { SelectIssuerDrawer } from './cert-manager';
+import { TrashIcon } from '@patternfly/react-icons';
 
 type WithAcceptorProps = {
   acceptor?: Acceptor;
@@ -196,76 +190,61 @@ const CertManagerAnnotation: FC<ResourceTemplateProps> = ({
     cr,
     resourceTemplate,
   );
-  const [isConfigExpanded, setIsConfigExpanded] = useState(false);
-  const [isActionOpen, setIsActionOpen] = useState(false);
-  const dropdownItems = [
-    <DropdownItem
-      key="action-delete"
-      component="button"
-      onClick={() =>
-        dispatch({
-          operation: ArtemisReducerOperations.deletePEMGenerationForAcceptor,
-          payload: acceptor.name,
-        })
+  return (
+    <FormFieldGroupExpandable
+      isExpanded
+      toggleAriaLabel="Details"
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: 'Cert-Manager Annotation',
+            id: 'nested-field-cert-manager-annotation-id' + acceptor.name,
+          }}
+          titleDescription="Configuration of the cert-manager annotation"
+          actions={
+            <Button
+              variant="plain"
+              aria-label="Remove"
+              onClick={() =>
+                dispatch({
+                  operation:
+                    ArtemisReducerOperations.deletePEMGenerationForAcceptor,
+                  payload: acceptor.name,
+                })
+              }
+            >
+              <TrashIcon />
+            </Button>
+          }
+        />
       }
     >
-      Delete
-    </DropdownItem>,
-  ];
-
-  return (
-    <ListItem>
-      <Split>
-        <SplitItem>
-          <Dropdown
-            onSelect={() => setIsActionOpen(!isActionOpen)}
-            toggle={
-              <KebabToggle
-                onToggle={(isOpen) => setIsActionOpen(isOpen)}
-                id="toggle-id-actions"
-              />
-            }
-            isOpen={isActionOpen}
-            isPlain
-            dropdownItems={dropdownItems}
-          />
-        </SplitItem>
-        <SplitItem isFilled>
-          <ExpandableSection
-            toggleText={'Cert-manager & ingress exposure annotation'}
-            onToggle={() => setIsConfigExpanded(!isConfigExpanded)}
-            isExpanded={isConfigExpanded}
-            isWidthLimited
-          >
-            <FormGroup label={t('select_issuer')} isRequired>
-              <SelectIssuerDrawer
-                selectedIssuer={
-                  resourceTemplate.annotations['cert-manager.io/issuer']
-                }
-                setSelectedIssuer={(issuer: string) => {
-                  dispatch({
-                    operation: ArtemisReducerOperations.updateAnnotationIssuer,
-                    payload: {
-                      acceptorName: acceptor.name,
-                      newIssuer: issuer,
-                    },
-                  });
-                }}
-                clearIssuer={() => {
-                  dispatch({
-                    operation: ArtemisReducerOperations.updateAnnotationIssuer,
-                    payload: {
-                      acceptorName: acceptor.name,
-                      newIssuer: '',
-                    },
-                  });
-                }}
-              />
-            </FormGroup>
-          </ExpandableSection>
-        </SplitItem>
-      </Split>
-    </ListItem>
+      <FormGroup label={t('select_issuer')} isRequired>
+        <SelectIssuerDrawer
+          selectedIssuer={
+            resourceTemplate.annotations['cert-manager.io/issuer']
+          }
+          setSelectedIssuer={(issuer: string) => {
+            dispatch({
+              operation: ArtemisReducerOperations.updateAnnotationIssuer,
+              payload: {
+                acceptorName: acceptor.name,
+                newIssuer: issuer,
+              },
+            });
+          }}
+          clearIssuer={() => {
+            dispatch({
+              operation: ArtemisReducerOperations.updateAnnotationIssuer,
+              payload: {
+                acceptorName: acceptor.name,
+                newIssuer: '',
+              },
+            });
+          }}
+        />
+      </FormGroup>
+    </FormFieldGroupExpandable>
   );
 };
 
@@ -311,11 +290,9 @@ export const ListAnnotations: FC<ListAnnotationsProps> = ({ acceptor }) => {
   }
   return (
     <>
-      <List isPlain>
-        {certManagerRt && (
-          <CertManagerAnnotation resourceTemplate={certManagerRt} />
-        )}
-      </List>
+      {certManagerRt && (
+        <CertManagerAnnotation resourceTemplate={certManagerRt} />
+      )}
     </>
   );
 };

--- a/src/configuration/acceptors-annotations.tsx
+++ b/src/configuration/acceptors-annotations.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ButtonVariant,
   Card,
   CardBody,
   CardTitle,
@@ -35,7 +36,7 @@ interface AddIssuerAnnotationModalProps extends WithAcceptorProps {
   setIsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const AddAnnotationModal: FC<AddIssuerAnnotationModalProps> = ({
+const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
   isModalOpen,
   setIsModalOpen,
   acceptor: initialAcceptor,
@@ -180,9 +181,7 @@ type ResourceTemplateProps = {
   resourceTemplate: ResourceTemplate;
 };
 
-const CertManagerAnnotation: FC<ResourceTemplateProps> = ({
-  resourceTemplate,
-}) => {
+const CertManagerPreset: FC<ResourceTemplateProps> = ({ resourceTemplate }) => {
   const { cr } = useContext(BrokerCreationFormState);
   const { t } = useTranslation();
   const dispatch = useContext(BrokerCreationFormDispatch);
@@ -197,10 +196,10 @@ const CertManagerAnnotation: FC<ResourceTemplateProps> = ({
       header={
         <FormFieldGroupHeader
           titleText={{
-            text: 'Cert-Manager Annotation',
+            text: 'Cert-Manager issuer & Ingress exposure',
             id: 'nested-field-cert-manager-annotation-id' + acceptor.name,
           }}
-          titleDescription="Configuration of the cert-manager annotation"
+          titleDescription="Configuration items for the preset"
           actions={
             <Button
               variant="plain"
@@ -248,38 +247,34 @@ const CertManagerAnnotation: FC<ResourceTemplateProps> = ({
   );
 };
 
-type NewAnnotationCardsProps = {
+type PreconfigurationButtonProps = {
   acceptor: Acceptor;
 };
-/**
- * Displays a card per available annotation for the given acceptor;
- * If the annotation is already applied, the card gets disabled and is in the
- * "selected" mode.
- */
-export const NewAnnotationButton: FC<NewAnnotationCardsProps> = ({
-  acceptor,
-}) => {
-  const [showIssuerAnnotationModal, setShowIssuerAnnotationModal] =
-    useState(false);
+
+export const PresetButton: FC<PreconfigurationButtonProps> = ({ acceptor }) => {
+  const [showPresetModal, setShowPresetModal] = useState(false);
   return (
     <>
-      <AddAnnotationModal
-        isModalOpen={showIssuerAnnotationModal}
-        setIsModalOpen={setShowIssuerAnnotationModal}
+      <AddPresetModal
+        isModalOpen={showPresetModal}
+        setIsModalOpen={setShowPresetModal}
         acceptor={acceptor}
       />
-      <Button onClick={() => setShowIssuerAnnotationModal(true)}>
-        Add an annotation
+      <Button
+        variant={ButtonVariant.link}
+        onClick={() => setShowPresetModal(true)}
+      >
+        Apply preset
       </Button>
     </>
   );
 };
 
-type ListAnnotationsProps = {
+type ListPresetsProps = {
   acceptor: Acceptor;
 };
 
-export const ListAnnotations: FC<ListAnnotationsProps> = ({ acceptor }) => {
+export const ListPresets: FC<ListPresetsProps> = ({ acceptor }) => {
   const { cr } = useContext(BrokerCreationFormState);
   const certManagerRt = getCertManagerResourceTemplateFromAcceptor(
     cr,
@@ -290,9 +285,7 @@ export const ListAnnotations: FC<ListAnnotationsProps> = ({ acceptor }) => {
   }
   return (
     <>
-      {certManagerRt && (
-        <CertManagerAnnotation resourceTemplate={certManagerRt} />
-      )}
+      {certManagerRt && <CertManagerPreset resourceTemplate={certManagerRt} />}
     </>
   );
 };

--- a/src/configuration/acceptors-config.tsx
+++ b/src/configuration/acceptors-config.tsx
@@ -17,24 +17,13 @@ import { FC, Fragment, useContext, useState } from 'react';
 import {
   Button,
   Checkbox,
-  Divider,
-  Dropdown,
-  DropdownItem,
-  ExpandableSection,
-  Flex,
-  FlexItem,
   FormGroup,
   FormSelect,
   FormSelectOption,
-  KebabToggle,
-  List,
-  ListItem,
   SearchInput,
   Select,
   SelectOption,
   SelectVariant,
-  Split,
-  SplitItem,
   Stack,
   StackItem,
   Switch,
@@ -42,16 +31,21 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Grid,
+  FormFieldGroup,
+  FormFieldGroupHeader,
+  FormFieldGroupExpandable,
 } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 import {
   ConfigType,
-  NamingPanel,
   CertSecretSelector,
   ConfigTypeContext,
+  ConfigRenamingModal,
 } from './broker-models';
 import { useTranslation } from 'react-i18next';
 import { ListAnnotations, NewAnnotationButton } from './acceptors-annotations';
+import { Form } from '@patternfly/react-core/dist/js';
 
 export type AcceptorProps = {
   configName: string;
@@ -293,20 +287,27 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
 
   return (
     <>
-      <Flex>
-        <FlexItem>
+      <FormFieldGroup
+        header={
+          <FormFieldGroupHeader
+            titleText={{
+              text: 'Global configuration',
+              id: 'field-group-configuration' + configName,
+            }}
+          />
+        }
+      >
+        <Grid hasGutter md={6}>
           <FormGroup
             label="Factory Class"
             isRequired
             fieldId={'horizontal-form-factory-' + configType + configName}
-            key={'formgroup-factory' + configType + configName}
           >
             <FormSelect
               label="acceptorFactoryClass"
               value={selectedClass}
               onChange={onChangeClass}
               aria-label="FormSelect Input"
-              key={'select' + configType + configName}
             >
               {options.map((option, index) => (
                 <FormSelectOption
@@ -318,14 +319,11 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               ))}
             </FormSelect>
           </FormGroup>
-        </FlexItem>
-        {configType === ConfigType.connectors && (
-          <FlexItem>
+          {configType === ConfigType.connectors && (
             <FormGroup
               label="Host"
               isRequired
               fieldId={'horizontal-form-host-' + configType + configName}
-              key={'host' + configType + configName}
             >
               <TextInput
                 isDisabled={selectedClass === 'invm'}
@@ -338,14 +336,11 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 onChange={onHostChange}
               />
             </FormGroup>
-          </FlexItem>
-        )}
-        <FlexItem>
+          )}
           <FormGroup
             label="Port"
             isRequired
             fieldId={'horizontal-form-port-' + configType + configName}
-            key={'port' + configType + configName}
           >
             <TextInput
               isDisabled={selectedClass === 'invm'}
@@ -358,13 +353,10 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               onChange={onPortChange}
             />
           </FormGroup>
-        </FlexItem>
-        <FlexItem>
           <FormGroup
             label="Protocols"
             isRequired
             fieldId="horizontal-form-protocols"
-            key={'protocol' + configType + configName}
           >
             <TextInput
               value={protocols}
@@ -376,14 +368,11 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               onChange={onProtocolsChange}
             />
           </FormGroup>
-        </FlexItem>
-        {configType === ConfigType.acceptors && (
-          <FlexItem>
+          {configType === ConfigType.acceptors && (
             <FormGroup
               label="BindToAllInterfaces"
               isRequired
               fieldId="horizontal-form-bindToAllInterfaces"
-              key={'bindToAllInterfaces' + configType + configName}
             >
               <Checkbox
                 label="Bind to all interfaces"
@@ -393,10 +382,8 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 onChange={onBindToAllInterfacesChange}
               />
             </FormGroup>
-          </FlexItem>
-        )}
-        {configType === ConfigType.acceptors && (
-          <FlexItem>
+          )}
+          {configType === ConfigType.acceptors && (
             <FormGroup label="Expose" fieldId="horizontal-form-expose">
               <Checkbox
                 label="Expose"
@@ -418,10 +405,8 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 }
               />
             </FormGroup>
-          </FlexItem>
-        )}
-        {configType === ConfigType.acceptors && (
-          <FlexItem>
+          )}
+          {configType === ConfigType.acceptors && (
             <SelectExposeMode
               selectedExposeMode={
                 getAcceptor(cr, configName)
@@ -447,10 +432,8 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 })
               }
             />
-          </FlexItem>
-        )}
-        {configType === ConfigType.acceptors && (
-          <FlexItem>
+          )}
+          {configType === ConfigType.acceptors && (
             <FormGroup
               label="ingressHost"
               fieldId="horizontal-form-ingressHost"
@@ -476,14 +459,11 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
                 }
               />
             </FormGroup>
-          </FlexItem>
-        )}
-        <FlexItem>
+          )}
           <FormGroup
             label="Other parameters"
             isRequired
             fieldId="horizontal-form-otherParams"
-            key={'other' + configType + configName}
           >
             <TextInput
               value={otherParams}
@@ -495,8 +475,6 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               onChange={onOtherParamsChange}
             />
           </FormGroup>
-        </FlexItem>
-        <FlexItem>
           <FormGroup
             label="Annotations"
             isRequired
@@ -505,57 +483,60 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
           >
             <NewAnnotationButton acceptor={getAcceptor(cr, configName)} />
           </FormGroup>
-        </FlexItem>
-      </Flex>
-      <Flex>
-        <div className="pf-u-pt-xl"></div>
-        <FlexItem>
-          <Switch
-            key={'switch' + configType + configName}
-            id={'ssl-switch' + configType + configName}
-            label="SSL Enabled"
-            labelOff="SSL disabled"
-            isChecked={isSSLEnabled}
-            onChange={handleSSLEnabled}
-            ouiaId="BasicSwitch"
+          <FormGroup
+            label="Encryption"
+            fieldId="horizontal-form-Encryption"
+            isRequired
+          >
+            <Switch
+              id={'ssl-switch' + configType + configName}
+              label="SSL Enabled"
+              labelOff="SSL disabled"
+              isChecked={isSSLEnabled}
+              onChange={handleSSLEnabled}
+              ouiaId="BasicSwitch"
+            />
+          </FormGroup>
+        </Grid>
+      </FormFieldGroup>
+      {isSSLEnabled && (
+        <FormFieldGroup
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'SSL configuration',
+                id: 'field-group-configuration-ssl' + configName,
+              }}
+            />
+          }
+        >
+          <CertSecretSelector
+            namespace={cr.metadata.namespace}
+            isCa={false}
+            configType={configType}
+            configName={configName}
           />
-          <Divider orientation={{ default: 'horizontal' }} />
-          <div className="pf-u-pt-xl"></div>
-          {isSSLEnabled && (
-            <Flex direction={{ default: 'row' }}>
-              <FlexItem>
-                <CertSecretSelector
-                  key={'secret-key' + configType + configName}
-                  namespace={cr.metadata.namespace}
-                  isCa={false}
-                  configType={configType}
-                  configName={configName}
-                />
-              </FlexItem>
-              <FlexItem>
-                <CertSecretSelector
-                  key={'secret-ca' + configType + configName}
-                  namespace={cr.metadata.namespace}
-                  isCa={true}
-                  configType={configType}
-                  configName={configName}
-                />
-              </FlexItem>
-            </Flex>
-          )}
-        </FlexItem>
-      </Flex>
-      {configType === ConfigType.acceptors && cr.spec.resourceTemplates && (
-        <Flex>
-          <div className="pf-u-pt-xl"></div>
-          <FlexItem>
-            <FormGroup label="Annotations">
-              <Divider orientation={{ default: 'horizontal' }} />
-              <div className="pf-u-pt-xl"></div>
-              <ListAnnotations acceptor={getAcceptor(cr, configName)} />
-            </FormGroup>
-          </FlexItem>
-        </Flex>
+          <CertSecretSelector
+            namespace={cr.metadata.namespace}
+            isCa={true}
+            configType={configType}
+            configName={configName}
+          />
+        </FormFieldGroup>
+      )}
+      {configType === ConfigType.acceptors && (
+        <FormFieldGroup
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'Annotations',
+                id: 'field-group-configuration-annotations' + configName,
+              }}
+            />
+          }
+        >
+          <ListAnnotations acceptor={getAcceptor(cr, configName)} />
+        </FormFieldGroup>
       )}
     </>
   );
@@ -570,27 +551,7 @@ export const AcceptorConfigSection: FC<AcceptorConfigSectionProps> = ({
   configType,
   configName,
 }) => {
-  const { t } = useTranslation();
-  const { cr } = useContext(BrokerCreationFormState);
   const dispatch = useContext(BrokerCreationFormDispatch);
-
-  const [isConfigExpanded, setIsConfigExpanded] = useState(false);
-
-  const [isActionOpen, setIsActionOpen] = useState(false);
-  const [isNaming, setIsNaming] = useState(false);
-
-  const onToggleAcceptorConfig = (expanded: boolean) => {
-    setIsConfigExpanded(expanded);
-  };
-
-  const onSelectAction = (_event: any) => {
-    setIsActionOpen(!isActionOpen);
-  };
-
-  const onToggleActions = (isOpen: boolean) => {
-    setIsActionOpen(isOpen);
-  };
-
   const onDelete = () => {
     if (configType === ConfigType.acceptors) {
       dispatch({
@@ -606,60 +567,30 @@ export const AcceptorConfigSection: FC<AcceptorConfigSectionProps> = ({
     }
   };
 
-  const onRename = () => {
-    setIsNaming(true);
-  };
-
-  const dropdownItems = [
-    <DropdownItem key="action-rename" component="button" onClick={onRename}>
-      {t('rename')}
-    </DropdownItem>,
-    <DropdownItem key="action-delete" component="button" onClick={onDelete}>
-      {t('delete')}
-    </DropdownItem>,
-  ];
-
-  const getAcceptorNameSet = () => {
-    return listConfigs(configType, cr, 'set');
-  };
-
   return (
-    <Split>
-      <SplitItem>
-        <Dropdown
-          onSelect={onSelectAction}
-          toggle={
-            <KebabToggle onToggle={onToggleActions} id="toggle-id-actions" />
+    <FormFieldGroupExpandable
+      isExpanded
+      toggleAriaLabel="Details"
+      header={
+        <FormFieldGroupHeader
+          titleText={{
+            text: configName,
+            id: 'configName' + configName,
+          }}
+          titleDescription={configName + "'s details"}
+          actions={
+            <>
+              <ConfigRenamingModal initName={configName} />
+              <Button variant="plain" aria-label="Remove" onClick={onDelete}>
+                <TrashIcon />
+              </Button>
+            </>
           }
-          isOpen={isActionOpen}
-          isPlain
-          dropdownItems={dropdownItems}
         />
-      </SplitItem>
-      <SplitItem isFilled>
-        {isNaming && (
-          <NamingPanel
-            initName={configName}
-            uniqueSet={getAcceptorNameSet() as Set<string>}
-          />
-        )}
-        {!isNaming && (
-          <ExpandableSection
-            key={'configsection' + configType + configName}
-            toggleText={configName}
-            onToggle={onToggleAcceptorConfig}
-            isExpanded={isConfigExpanded}
-            isWidthLimited
-          >
-            <AcceptorConfigPage
-              key={'configpage' + configType + configName}
-              configType={configType}
-              configName={configName}
-            />
-          </ExpandableSection>
-        )}
-      </SplitItem>
-    </Split>
+      }
+    >
+      <AcceptorConfigPage configType={configType} configName={configName} />
+    </FormFieldGroupExpandable>
   );
 };
 
@@ -669,34 +600,12 @@ export type AcceptorsConfigProps = {
 
 export const AcceptorsConfigPage: FC<AcceptorsConfigProps> = ({ brokerId }) => {
   const { t } = useTranslation();
-  const fromState = useContext(BrokerCreationFormState);
+  const { cr } = useContext(BrokerCreationFormState);
   const configType = useContext(ConfigTypeContext);
   const dispatch = useContext(BrokerCreationFormDispatch);
-
-  const getAcceptorsFromModel = (brokerId: number): any[] => {
-    const { cr } = fromState;
-    const acceptors = [];
-
-    let i = 0;
-    const acceptorEntries = listConfigs(configType, cr) as {
-      name: string;
-    }[];
-
-    while (i < acceptorEntries.length) {
-      const entry = acceptorEntries[i];
-
-      acceptors.push(
-        <ListItem key={entry.name + brokerId}>
-          <AcceptorConfigSection
-            configType={configType}
-            configName={entry.name}
-          />
-        </ListItem>,
-      );
-      i++;
-    }
-    return acceptors;
-  };
+  const configs = listConfigs(configType, cr) as {
+    name: string;
+  }[];
 
   const addNewConfig = () => {
     if (configType === ConfigType.acceptors) {
@@ -731,14 +640,24 @@ export const AcceptorsConfigPage: FC<AcceptorsConfigProps> = ({ brokerId }) => {
     </Fragment>
   );
   return (
-    <Stack key={'stack' + configType}>
+    <Stack>
       <StackItem>
         <Toolbar id="toolbar-items-example">
           <ToolbarContent>{configToolbarItems}</ToolbarContent>
         </Toolbar>
       </StackItem>
       <StackItem isFilled>
-        <List isPlain>{getAcceptorsFromModel(brokerId)}</List>
+        <Form isHorizontal isWidthLimited>
+          {configs.map((config, index) => {
+            return (
+              <AcceptorConfigSection
+                key={config.name + brokerId + index}
+                configType={configType}
+                configName={config.name}
+              />
+            );
+          })}
+        </Form>
       </StackItem>
     </Stack>
   );

--- a/src/configuration/acceptors-config.tsx
+++ b/src/configuration/acceptors-config.tsx
@@ -26,7 +26,6 @@ import { Form } from '@patternfly/react-core/dist/js';
 import {
   BellIcon,
   PlusCircleIcon,
-  TrashIcon,
   WarningTriangleIcon,
 } from '@patternfly/react-icons';
 import { FC, Fragment, useContext, useState } from 'react';
@@ -54,6 +53,7 @@ import {
   ConfigType,
   ConfigTypeContext,
 } from './broker-models';
+import { ConfirmDeleteModal } from './confirmation-modal';
 
 type PresetCautionProps = {
   configType: ConfigType;
@@ -689,9 +689,12 @@ export const AcceptorConfigSection: FC<AcceptorConfigSectionProps> = ({
                 <PresetButton acceptor={getAcceptor(cr, configName)} />
               )}
               <ConfigRenamingModal initName={configName} />
-              <Button variant="plain" aria-label="Remove" onClick={onDelete}>
-                <TrashIcon />
-              </Button>
+              <ConfirmDeleteModal
+                subject={
+                  configType === ConfigType.acceptors ? 'acceptor' : 'connector'
+                }
+                action={onDelete}
+              />
             </>
           }
         />

--- a/src/configuration/confirmation-modal.tsx
+++ b/src/configuration/confirmation-modal.tsx
@@ -1,0 +1,60 @@
+import { Button, Modal, ModalVariant } from '@patternfly/react-core';
+import { ExclamationTriangleIcon, TrashIcon } from '@patternfly/react-icons';
+import { FC, useState } from 'react';
+
+type ConfirmDeleteProps = {
+  subject: string;
+  action: () => void;
+};
+
+export const ConfirmDeleteModal: FC<ConfirmDeleteProps> = ({
+  subject,
+  action,
+}) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  return (
+    <>
+      <Modal
+        variant={ModalVariant.small}
+        header={
+          <p>
+            <ExclamationTriangleIcon /> Permanently delete the {' ' + subject}
+          </p>
+        }
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        actions={[
+          <Button
+            key="confirm"
+            variant="danger"
+            onClick={() => {
+              try {
+                action();
+              } finally {
+                setIsModalOpen(false);
+              }
+            }}
+          >
+            Delete
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setIsModalOpen(false)}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        The associated configuration will be lost.
+      </Modal>
+      <Button
+        variant="plain"
+        aria-label="Remove"
+        onClick={() => setIsModalOpen(true)}
+      >
+        <TrashIcon />
+      </Button>
+    </>
+  );
+};

--- a/src/configuration/console-config.tsx
+++ b/src/configuration/console-config.tsx
@@ -1,25 +1,24 @@
 import {
   ArtemisReducerOperations,
-  BrokerCreationFormState,
   BrokerCreationFormDispatch,
+  BrokerCreationFormState,
   ExposeMode,
 } from '../brokers/utils';
+
 import {
   Checkbox,
-  Divider,
-  Flex,
-  FlexItem,
+  Form,
+  FormFieldGroup,
+  FormFieldGroupHeader,
   FormGroup,
   FormSelect,
   FormSelectOption,
-  Stack,
-  StackItem,
+  Grid,
   Switch,
 } from '@patternfly/react-core';
-
 import { FC, useContext, useState } from 'react';
-import { CertSecretSelector, ConfigType } from './broker-models';
 import { K8sResourceCommon } from '../utils';
+import { CertSecretSelector, ConfigType } from './broker-models';
 
 export type ConsoleConfigProps = {
   brokerId: number;
@@ -96,87 +95,76 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
   }
 
   return (
-    <Stack key={'stack' + brokerId}>
-      <StackItem isFilled>
-        <Flex>
-          <FlexItem>
-            <FormGroup
-              label="Expose"
-              fieldId={'console-config-expose-formgroup'}
-              key={'formgroup-console-expose'}
-            >
-              <Checkbox
-                label="Expose Console"
-                isChecked={exposeConsole}
-                name={'check-console-expose'}
-                id={'check-expose-console'}
-                onChange={setConsoleExpose}
-              />
-            </FormGroup>
-          </FlexItem>
-          <FlexItem>
-            <FormGroup
-              label="ExposeMode"
-              fieldId={'console-config-exposemode-formgroup'}
-              key={'formgroup-console-exposemode'}
-            >
-              <FormSelect
-                label="console expose mode"
-                value={exposeMode}
-                onChange={setConsoleExposeMode}
-                aria-label="formselect-expose-mode-aria-label"
-                key={'formselect-console-exposemode'}
-              >
-                {exposeModes.map((mode, index) => (
-                  <FormSelectOption
-                    key={'console-exposemode-option' + index}
-                    value={mode.value}
-                    label={mode.label}
-                  />
-                ))}
-              </FormSelect>
-            </FormGroup>
-          </FlexItem>
-        </Flex>
-        <Flex>
-          <div className="pf-u-pt-xl"></div>
-          <FlexItem>
-            <Switch
-              key={'switch-console-sslEnabled'}
-              id={'id-switch-console-sslEnabled'}
-              label="SSL Enabled for console"
-              labelOff="SSL disabled for console"
-              isChecked={isSSLEnabled}
-              onChange={handleSSLEnabled}
-              ouiaId="BasicSwitch-console-ssl"
+    <Form isHorizontal isWidthLimited key={'form' + brokerId}>
+      <Grid hasGutter md={6}>
+        <FormFieldGroup>
+          <FormGroup
+            label="Expose"
+            fieldId={'console-config-expose-formgroup'}
+            isRequired
+          >
+            <Checkbox
+              label="Expose Console"
+              isChecked={exposeConsole}
+              name={'check-console-expose'}
+              id={'check-expose-console'}
+              onChange={setConsoleExpose}
             />
-            <Divider orientation={{ default: 'horizontal' }} />
-            <div className="pf-u-pt-xl"></div>
-            {isSSLEnabled && (
-              <Flex direction={{ default: 'row' }}>
-                <FlexItem>
-                  <CertSecretSelector
-                    key={'secret-key' + ConfigType.console + 'console'}
-                    namespace={cr.metadata.namespace}
-                    isCa={false}
-                    configType={ConfigType.console}
-                    configName={'console'}
-                  />
-                </FlexItem>
-                <FlexItem>
-                  <CertSecretSelector
-                    key={'secret-ca' + ConfigType.console + 'console'}
-                    namespace={cr.metadata.namespace}
-                    isCa={true}
-                    configType={ConfigType.console}
-                    configName={'console'}
-                  />
-                </FlexItem>
-              </Flex>
-            )}
-          </FlexItem>
-        </Flex>
-      </StackItem>
-    </Stack>
+          </FormGroup>
+          <FormGroup
+            label="ExposeMode"
+            fieldId={'console-config-exposemode-formgroup'}
+          >
+            <FormSelect
+              label="console expose mode"
+              value={exposeMode}
+              onChange={setConsoleExposeMode}
+              aria-label="formselect-expose-mode-aria-label"
+            >
+              {exposeModes.map((mode, index) => (
+                <FormSelectOption
+                  key={'console-exposemode-option' + index}
+                  value={mode.value}
+                  label={mode.label}
+                />
+              ))}
+            </FormSelect>
+          </FormGroup>
+          <Switch
+            id={'id-switch-console-sslEnabled'}
+            label="SSL Enabled for console"
+            labelOff="SSL disabled for console"
+            isChecked={isSSLEnabled}
+            onChange={handleSSLEnabled}
+            ouiaId="BasicSwitch-console-ssl"
+          />
+        </FormFieldGroup>
+      </Grid>
+      {isSSLEnabled && (
+        <FormFieldGroup
+          header={
+            <FormFieldGroupHeader
+              titleText={{
+                text: 'SSL configuration',
+                id: 'field-group-configuration-ssl' + 'console',
+              }}
+            />
+          }
+        >
+          <CertSecretSelector
+            namespace={cr.metadata.namespace}
+            isCa={false}
+            configType={ConfigType.console}
+            configName={'console'}
+          />
+          <CertSecretSelector
+            namespace={cr.metadata.namespace}
+            isCa={true}
+            configType={ConfigType.console}
+            configName={'console'}
+          />
+        </FormFieldGroup>
+      )}
+    </Form>
   );
 };


### PR DESCRIPTION
  We can leverage the patternFly Form component at the root of the
    acceptor and connector configuration page. The Form component handles
    the layout for us and removes the need of flex organizers. Also it's
    easier to have fields aligning properly without having to deal with
    sideeffects when a subcomponent tries to get more space than it was
    doing before.

depends on: #162 