### PR TITLE
[NOISSUE] form header using patternfly components

### DIFF
--- a/src/brokers/add-broker/components/AddBrokerForm/BrokerProperties.tsx
+++ b/src/brokers/add-broker/components/AddBrokerForm/BrokerProperties.tsx
@@ -1,17 +1,18 @@
-import { GetConfigurationPage } from '../../../../configuration/broker-models';
+import {
+  ConfigType,
+  GetConfigurationPage,
+} from '../../../../configuration/broker-models';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionToggle,
-  Divider,
-  SimpleList,
-  SimpleListItem,
+  JumpLinks,
+  JumpLinksItem,
   Split,
   SplitItem,
-  Title,
 } from '@patternfly/react-core';
-import { FC, useState } from 'react';
+import { CSSProperties, FC, useState } from 'react';
 
 export type BrokerIDProp = {
   brokerId: number;
@@ -87,61 +88,54 @@ export const BrokerProperties: FC<BrokerIDProp> = ({
 }) => {
   console.log('configuring broker ', crName, 'in namespace', targetNs);
 
-  const [currentConfigItem, setCurrentConfigItem] = useState('');
-
-  const onSelectBrokerConfigItem = (
-    selectedItem: any,
-    selectedItemProps: any,
-  ) => {
-    console.log('new selection selected', selectedItem);
-    setCurrentConfigItem(selectedItemProps.itemId);
-  };
-
-  const brokerConfigItems = [
-    <SimpleListItem key={'acceptors' + brokerId} itemId="acceptors">
-      <Title headingLevel="h4" key="title.acceptors">
-        Acceptors
-      </Title>
-    </SimpleListItem>,
-    <SimpleListItem key={'connectors' + brokerId} itemId="connectors">
-      <Title headingLevel="h4" key="title.connectors">
-        Connectors
-      </Title>
-    </SimpleListItem>,
-    <SimpleListItem key={'console' + brokerId} itemId="console">
-      <Title headingLevel="h4" key="title.console">
-        Console
-      </Title>
-    </SimpleListItem>,
-  ];
+  const [currentConfigItem, setCurrentConfigItem] = useState<ConfigType>(
+    ConfigType.acceptors,
+  );
 
   return (
-    <Split hasGutter key={'split.config.broker' + brokerId}>
-      <SplitItem key={'splititem.config.broker' + brokerId}>
-        <SimpleList
-          onSelect={onSelectBrokerConfigItem}
-          aria-label="Broker Config List"
-          key={'config.broker.container.' + brokerId}
-        >
-          {brokerConfigItems}
-        </SimpleList>
+    <Split hasGutter>
+      <SplitItem>
+        <JumpLinks isVertical aria-label="Broker Config List">
+          <JumpLinksItem
+            onClick={() => setCurrentConfigItem(ConfigType.acceptors)}
+            isActive={currentConfigItem === ConfigType.acceptors}
+            style={
+              {
+                'list-style': 'none' /* reset to patternfly default value*/,
+              } as CSSProperties
+            }
+          >
+            Acceptors
+          </JumpLinksItem>
+          <JumpLinksItem
+            onClick={() => setCurrentConfigItem(ConfigType.connectors)}
+            isActive={currentConfigItem === ConfigType.connectors}
+            style={
+              {
+                'list-style': 'none' /* reset to patternfly default value*/,
+              } as CSSProperties
+            }
+          >
+            Connectors
+          </JumpLinksItem>
+          <JumpLinksItem
+            onClick={() => setCurrentConfigItem(ConfigType.console)}
+            isActive={currentConfigItem === ConfigType.console}
+            style={
+              {
+                'list-style': 'none' /* reset to patternfly default value*/,
+              } as CSSProperties
+            }
+          >
+            Console
+          </JumpLinksItem>
+        </JumpLinks>
       </SplitItem>
-      <Divider
-        orientation={{
-          default: 'vertical',
-        }}
-        inset={{
-          default: 'insetMd',
-          md: 'insetNone',
-          lg: 'insetSm',
-          xl: 'insetXs',
-        }}
-      />
-      <SplitItem isFilled key={'splititem.config.broker.details' + brokerId}>
+      <SplitItem>
         <GetConfigurationPage
-          key={'getconfigurationpage.config.broker' + brokerId}
           target={currentConfigItem}
           isPerBrokerConfig={perBrokerProperties}
+          brokerId={brokerId}
         />
       </SplitItem>
     </Split>

--- a/src/brokers/add-broker/components/AddBrokerForm/FormView.tsx
+++ b/src/brokers/add-broker/components/AddBrokerForm/FormView.tsx
@@ -1,35 +1,33 @@
-import { FC, useContext, useEffect, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  Form,
+  ActionGroup,
   Alert,
   AlertGroup,
   AlertVariant,
-  StackItem,
-  Stack,
-  TextInput,
-  Flex,
-  FlexItem,
-  Divider,
+  Banner,
+  Button,
+  ButtonVariant,
+  Form,
+  FormFieldGroup,
   FormGroup,
-  Switch,
-  NumberInput,
-  InputGroup,
-  InputGroupText,
   FormSelect,
   FormSelectOption,
-  Title,
-  Banner,
+  Grid,
+  InputGroup,
+  InputGroupText,
+  NumberInput,
+  Switch,
+  TextInput,
 } from '@patternfly/react-core';
+import { FC, useContext, useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { useTranslation } from '../../../../i18n';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { BrokerProperties, BrokerPropertiesList } from './BrokerProperties';
 import {
   ArtemisReducerOperations,
-  BrokerCreationFormState,
   BrokerCreationFormDispatch,
+  BrokerCreationFormState,
 } from '../../../utils';
-import { BrokerActionGroup } from './ActionGroup';
+import { BrokerProperties, BrokerPropertiesList } from './BrokerProperties';
 
 type FormViewProps = {
   onCreateBroker: (formValues: K8sResourceCommon) => void;
@@ -81,6 +79,7 @@ export const FormView: FC<FormViewProps> = ({
     const isValid = validateFormFields(formState.cr);
     if (isValid) {
       onCreateBroker(formState.cr);
+      history.push('/k8s/all-namespaces/brokers');
     }
   };
 
@@ -120,103 +119,82 @@ export const FormView: FC<FormViewProps> = ({
   const crName = formState.cr.metadata.name;
   const replicas = formState.cr.spec.deploymentPlan.size;
   return (
-    <Form
-      isWidthLimited
-      className="pf-u-mx-md"
-      maxWidth="100%"
-      onSubmit={(e: React.FormEvent<HTMLFormElement>): void => {
-        e.preventDefault();
-      }}
-    >
-      {notification.title && (
-        <AlertGroup>
-          <Alert
-            data-test="add-broker-notification-form-view"
-            title={notification.title}
-            variant={notification.variant}
-            isInline
-            actionClose
-          />
-        </AlertGroup>
-      )}
-      <Stack hasGutter={true} name="broker view stack">
-        <StackItem>
-          <Flex>
-            <FlexItem>
-              <FormGroup
-                label="CR Name"
+    <>
+      <Form isHorizontal isWidthLimited>
+        {notification.title && (
+          <AlertGroup>
+            <Alert
+              data-test="add-broker-notification-form-view"
+              title={notification.title}
+              variant={notification.variant}
+              isInline
+              actionClose
+            />
+          </AlertGroup>
+        )}
+        <FormFieldGroup>
+          <Grid hasGutter md={6}>
+            <FormGroup
+              label="CR Name"
+              isRequired
+              fieldId="horizontal-form-name"
+            >
+              <TextInput
+                value={crName}
                 isRequired
-                fieldId="horizontal-form-name"
-              >
-                <TextInput
-                  value={crName}
-                  isRequired
-                  type="text"
-                  id="horizontal-form-name"
-                  aria-describedby="horizontal-form-name-helper"
-                  name="horizontal-form-name"
-                  onChange={handleNameChange}
-                />
-              </FormGroup>
-            </FlexItem>
-            <FlexItem>
-              <FormGroup
-                label="Replicas"
-                isRequired
-                fieldId="horizontal-form-name"
-              >
-                <NumberInput
-                  value={replicas}
-                  min={1}
-                  max={1024}
-                  onMinus={() =>
-                    dispatch({
-                      operation: ArtemisReducerOperations.decrementReplicas,
-                    })
-                  }
-                  onChange={(event) =>
-                    dispatch({
-                      operation: ArtemisReducerOperations.setReplicasNumber,
-                      payload: Number((event.target as HTMLInputElement).value),
-                    })
-                  }
-                  onPlus={() =>
-                    dispatch({
-                      operation: ArtemisReducerOperations.incrementReplicas,
-                    })
-                  }
-                  inputName="input"
-                  inputAriaLabel="number input"
-                  minusBtnAriaLabel="minus"
-                  plusBtnAriaLabel="plus"
-                />
-              </FormGroup>
-            </FlexItem>
-            <FlexItem>
-              <FormGroup label="ingressDomain" fieldId="horizontal-form-Domain">
-                <TextInput
-                  label="Ingress Domain"
-                  name={'ingressDomain'}
-                  id={'ingressDomain'}
-                  value={cr.spec?.ingressDomain}
-                  onChange={(v) =>
-                    dispatch({
-                      operation: ArtemisReducerOperations.setIngressDomain,
-                      payload: v,
-                    })
-                  }
-                />
-              </FormGroup>
-            </FlexItem>
-          </Flex>
-        </StackItem>
-        <Divider component="div" />
-        <StackItem>
-          <Flex justifyContent={{ default: 'justifyContentFlexStart' }}>
-            <FlexItem>
-              <Title headingLevel="h4">Broker Properties</Title>
-            </FlexItem>
-            <FlexItem>
+                type="text"
+                id="horizontal-form-name"
+                aria-describedby="horizontal-form-name-helper"
+                name="horizontal-form-name"
+                onChange={handleNameChange}
+              />
+            </FormGroup>
+            <FormGroup
+              label="Replicas"
+              isRequired
+              fieldId="horizontal-form-name"
+            >
+              <NumberInput
+                value={replicas}
+                min={1}
+                max={1024}
+                onMinus={() =>
+                  dispatch({
+                    operation: ArtemisReducerOperations.decrementReplicas,
+                  })
+                }
+                onChange={(event) =>
+                  dispatch({
+                    operation: ArtemisReducerOperations.setReplicasNumber,
+                    payload: Number((event.target as HTMLInputElement).value),
+                  })
+                }
+                onPlus={() =>
+                  dispatch({
+                    operation: ArtemisReducerOperations.incrementReplicas,
+                  })
+                }
+                inputName="input"
+                inputAriaLabel="number input"
+                minusBtnAriaLabel="minus"
+                plusBtnAriaLabel="plus"
+              />
+            </FormGroup>
+            <FormGroup label="ingressDomain" fieldId="horizontal-form-Domain">
+              <TextInput
+                label="Ingress Domain"
+                name={'ingressDomain'}
+                id={'ingressDomain'}
+                value={cr.spec?.ingressDomain}
+                onChange={(v) =>
+                  dispatch({
+                    operation: ArtemisReducerOperations.setIngressDomain,
+                    payload: v,
+                  })
+                }
+              />
+            </FormGroup>
+            <FormGroup label="Broker Properties">
               <InputGroup>
                 <InputGroupText id="broker-version" className=".pf-u-w-initial">
                   Version:
@@ -236,28 +214,28 @@ export const FormView: FC<FormViewProps> = ({
                   ))}
                 </FormSelect>
               </InputGroup>
-            </FlexItem>
-            <FlexItem>
+            </FormGroup>
+            <FormGroup label="Per broker config">
               <Switch
                 id="simple-switch"
-                label="per broker config"
-                labelOff="per broker config(disabled)"
+                label="enabled"
+                labelOff="disabled"
                 isChecked={isPerBrokerConfig}
                 onChange={handleChange}
                 ouiaId="BasicSwitch"
                 isDisabled={replicas <= 1}
               />
-            </FlexItem>
-          </Flex>
-        </StackItem>
-        <StackItem>
-          <Banner variant={'info'}>
-            <b>{crName}</b>
-            {' in namespace '}
-            <b>{targetNs}</b>
-          </Banner>
-        </StackItem>
-        <StackItem isFilled>
+            </FormGroup>
+          </Grid>
+        </FormFieldGroup>
+      </Form>
+      <Form isHorizontal>
+        <Banner variant={'info'}>
+          <b>{crName}</b>
+          {' in namespace '}
+          <b>{targetNs}</b>
+        </Banner>
+        <FormFieldGroup>
           {isPerBrokerConfig && replicas > 1 ? (
             <BrokerPropertiesList
               replicas={replicas}
@@ -272,13 +250,24 @@ export const FormView: FC<FormViewProps> = ({
               targetNs={targetNs}
             />
           )}
-        </StackItem>
-      </Stack>
-      <BrokerActionGroup
-        isUpdate={isUpdate}
-        onSubmit={onSubmit}
-        onCancel={onCancel}
-      ></BrokerActionGroup>
-    </Form>
+        </FormFieldGroup>
+      </Form>
+      <Form>
+        <FormFieldGroup>
+          <ActionGroup>
+            <Button
+              variant={ButtonVariant.primary}
+              type="submit"
+              onClick={onSubmit}
+            >
+              {isUpdate ? t('apply') : t('create')}
+            </Button>
+            <Button variant={ButtonVariant.link} onClick={onCancel}>
+              {t('cancel')}
+            </Button>
+          </ActionGroup>
+        </FormFieldGroup>
+      </Form>
+    </>
   );
 };

--- a/src/configuration/acceptors-config.tsx
+++ b/src/configuration/acceptors-config.tsx
@@ -1,7 +1,12 @@
 import {
+  ActionGroup,
   Alert,
   Button,
   Checkbox,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
   FormFieldGroup,
   FormFieldGroupExpandable,
   FormFieldGroupHeader,
@@ -10,25 +15,20 @@ import {
   FormSelectOption,
   Grid,
   Popover,
-  SearchInput,
   Select,
   SelectOption,
   SelectVariant,
-  Stack,
-  StackItem,
   Switch,
   TextInput,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
+  Title,
 } from '@patternfly/react-core';
 import { Form } from '@patternfly/react-core/dist/js';
 import {
   BellIcon,
-  PlusCircleIcon,
+  CubesIcon,
   WarningTriangleIcon,
 } from '@patternfly/react-icons';
-import { FC, Fragment, useContext, useState } from 'react';
+import { FC, useContext, useState } from 'react';
 import {
   ArtemisReducerOperations,
   BrokerCreationFormDispatch,
@@ -710,13 +710,12 @@ export type AcceptorsConfigProps = {
 };
 
 export const AcceptorsConfigPage: FC<AcceptorsConfigProps> = ({ brokerId }) => {
-  const { t } = useTranslation();
   const { cr } = useContext(BrokerCreationFormState);
   const configType = useContext(ConfigTypeContext);
-  const dispatch = useContext(BrokerCreationFormDispatch);
   const configs = listConfigs(configType, cr) as {
     name: string;
   }[];
+  const dispatch = useContext(BrokerCreationFormDispatch);
 
   const addNewConfig = () => {
     if (configType === ConfigType.acceptors) {
@@ -731,45 +730,42 @@ export const AcceptorsConfigPage: FC<AcceptorsConfigProps> = ({ brokerId }) => {
     }
   };
 
-  const configToolbarItems = (
-    <Fragment>
-      <ToolbarItem variant="search-filter">
-        <SearchInput
-          aria-label="search acceptors"
-          placeholder={t('search_acceptors')}
-        />
-      </ToolbarItem>
-      <ToolbarItem>
-        <Button
-          variant="plain"
-          aria-label="Add new acceptors"
-          onClick={addNewConfig}
-        >
-          <PlusCircleIcon size="md" />
+  const name = configType === ConfigType.acceptors ? 'acceptor' : 'connector';
+  const pronoun = configType === ConfigType.acceptors ? 'an' : 'a';
+  if (configs.length === 0) {
+    return (
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={CubesIcon} />
+        <Title headingLevel="h4" size="lg">
+          No {name} configured
+        </Title>
+        <EmptyStateBody>
+          There's no {name} in your configuration, to add one click on the
+          button below.{' '}
+        </EmptyStateBody>
+        <Button variant="primary" onClick={addNewConfig}>
+          Add {pronoun} {name}
         </Button>
-      </ToolbarItem>
-    </Fragment>
-  );
+      </EmptyState>
+    );
+  }
+
   return (
-    <Stack>
-      <StackItem>
-        <Toolbar id="toolbar-items-example">
-          <ToolbarContent>{configToolbarItems}</ToolbarContent>
-        </Toolbar>
-      </StackItem>
-      <StackItem isFilled>
-        <Form isHorizontal isWidthLimited>
-          {configs.map((config, index) => {
-            return (
-              <AcceptorConfigSection
-                key={config.name + brokerId + index}
-                configType={configType}
-                configName={config.name}
-              />
-            );
-          })}
-        </Form>
-      </StackItem>
-    </Stack>
+    <Form isHorizontal isWidthLimited>
+      {configs.map((config, index) => {
+        return (
+          <AcceptorConfigSection
+            key={config.name + brokerId + index}
+            configType={configType}
+            configName={config.name}
+          />
+        );
+      })}
+      <ActionGroup>
+        <Button variant="primary" onClick={addNewConfig}>
+          Add {pronoun} {name}
+        </Button>
+      </ActionGroup>
+    </Form>
   );
 };

--- a/src/configuration/broker-models.tsx
+++ b/src/configuration/broker-models.tsx
@@ -82,7 +82,6 @@ export const BrokerComponentConfig: FC<
     <Stack>
       <StackItem>
         <Title headingLevel="h2">{category}</Title>
-        <Divider orientation={{ default: 'horizontal' }} />
       </StackItem>
       <StackItem isFilled>{children}</StackItem>
     </Stack>
@@ -90,6 +89,7 @@ export const BrokerComponentConfig: FC<
 };
 
 export type BrokerConfigProps = {
+  brokerId: number;
   target: any;
   isPerBrokerConfig: boolean;
 };
@@ -802,6 +802,7 @@ export const ConfigTypeContext = createContext<ConfigType>(
 );
 
 export const GetConfigurationPage: FC<BrokerConfigProps> = ({
+  brokerId,
   target,
   isPerBrokerConfig,
 }) => {
@@ -815,13 +816,11 @@ export const GetConfigurationPage: FC<BrokerConfigProps> = ({
   if (target) {
     return (
       <ConfigTypeContext.Provider value={configType}>
-        <BrokerComponentConfig key={'brokerconfig' + target} category={target}>
-          {target === 'console' ? (
-            <ConsoleConfigPage brokerId={0} />
-          ) : (
-            <AcceptorsConfigPage brokerId={0} />
-          )}
-        </BrokerComponentConfig>
+        {target === 'console' ? (
+          <ConsoleConfigPage brokerId={brokerId} />
+        ) : (
+          <AcceptorsConfigPage brokerId={brokerId} />
+        )}
       </ConfigTypeContext.Provider>
     );
   }

--- a/src/configuration/console-config.tsx
+++ b/src/configuration/console-config.tsx
@@ -9,6 +9,7 @@ import {
   Checkbox,
   Form,
   FormFieldGroup,
+  FormFieldGroupExpandable,
   FormFieldGroupHeader,
   FormGroup,
   FormSelect,
@@ -96,50 +97,62 @@ export const ConsoleConfigPage: FC<ConsoleConfigProps> = ({ brokerId }) => {
 
   return (
     <Form isHorizontal isWidthLimited key={'form' + brokerId}>
-      <Grid hasGutter md={6}>
-        <FormFieldGroup>
-          <FormGroup
-            label="Expose"
-            fieldId={'console-config-expose-formgroup'}
-            isRequired
-          >
-            <Checkbox
-              label="Expose Console"
-              isChecked={exposeConsole}
-              name={'check-console-expose'}
-              id={'check-expose-console'}
-              onChange={setConsoleExpose}
-            />
-          </FormGroup>
-          <FormGroup
-            label="ExposeMode"
-            fieldId={'console-config-exposemode-formgroup'}
-          >
-            <FormSelect
-              label="console expose mode"
-              value={exposeMode}
-              onChange={setConsoleExposeMode}
-              aria-label="formselect-expose-mode-aria-label"
-            >
-              {exposeModes.map((mode, index) => (
-                <FormSelectOption
-                  key={'console-exposemode-option' + index}
-                  value={mode.value}
-                  label={mode.label}
-                />
-              ))}
-            </FormSelect>
-          </FormGroup>
-          <Switch
-            id={'id-switch-console-sslEnabled'}
-            label="SSL Enabled for console"
-            labelOff="SSL disabled for console"
-            isChecked={isSSLEnabled}
-            onChange={handleSSLEnabled}
-            ouiaId="BasicSwitch-console-ssl"
+      <FormFieldGroupExpandable
+        isExpanded
+        header={
+          <FormFieldGroupHeader
+            titleText={{
+              text: 'Console configuration',
+              id: 'field-group-consoleconfig' + 'console',
+            }}
           />
-        </FormFieldGroup>
-      </Grid>
+        }
+      >
+        <Grid hasGutter md={6}>
+          <FormFieldGroup>
+            <FormGroup
+              label="Expose"
+              fieldId={'console-config-expose-formgroup'}
+              isRequired
+            >
+              <Checkbox
+                label="Expose Console"
+                isChecked={exposeConsole}
+                name={'check-console-expose'}
+                id={'check-expose-console'}
+                onChange={setConsoleExpose}
+              />
+            </FormGroup>
+            <FormGroup
+              label="ExposeMode"
+              fieldId={'console-config-exposemode-formgroup'}
+            >
+              <FormSelect
+                label="console expose mode"
+                value={exposeMode}
+                onChange={setConsoleExposeMode}
+                aria-label="formselect-expose-mode-aria-label"
+              >
+                {exposeModes.map((mode, index) => (
+                  <FormSelectOption
+                    key={'console-exposemode-option' + index}
+                    value={mode.value}
+                    label={mode.label}
+                  />
+                ))}
+              </FormSelect>
+            </FormGroup>
+            <Switch
+              id={'id-switch-console-sslEnabled'}
+              label="SSL Enabled for console"
+              labelOff="SSL disabled for console"
+              isChecked={isSSLEnabled}
+              onChange={handleSSLEnabled}
+              ouiaId="BasicSwitch-console-ssl"
+            />
+          </FormFieldGroup>
+        </Grid>
+      </FormFieldGroupExpandable>
       {isSSLEnabled && (
         <FormFieldGroup
           header={


### PR DESCRIPTION
Use patternfly components to group items together instead of Flex layouts.

Amongst other improvement:

* empty state for when there's no acceptor / connector
* removing of the inactive search field
* new emplacement for the add button