### PR TITLE
[NOISSUE] breadcrumb speed fix

### DIFF
--- a/src/shared-components/AddressDetailsBreadcrumb/AddressDetailsBreadcrumb.tsx
+++ b/src/shared-components/AddressDetailsBreadcrumb/AddressDetailsBreadcrumb.tsx
@@ -2,10 +2,12 @@ import { FC } from 'react';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Button,
   Level,
   LevelItem,
 } from '@patternfly/react-core';
 import { useTranslation } from '../../i18n';
+import { useHistory } from 'react-router';
 
 export type AddressBreadcrumbProps = {
   name: string;
@@ -26,22 +28,43 @@ const AddressDetailsBreadcrumb: FC<AddressBreadcrumbProps> = ({
   const redirectBrokerPodsPath = `/k8s/ns/${namespace}/brokers/${brokerName}`;
   const redirectBrokerDetailsPath = `/k8s/ns/${namespace}/brokers/${brokerName}/${podName}`;
   const redirectAddressPath = `/k8s/ns/${namespace}/brokers/${brokerName}/${podName}?tab=addresses`;
+  const history = useHistory();
 
   return (
     <Level>
       <LevelItem>
         <Breadcrumb className="pf-u-mb-md">
-          <BreadcrumbItem to={redirectBrokerPath}>
-            {t('brokers')}
+          <BreadcrumbItem>
+            <Button
+              variant="link"
+              onClick={() => history.push(redirectBrokerPath)}
+            >
+              {t('brokers')}
+            </Button>
           </BreadcrumbItem>
-          <BreadcrumbItem to={redirectBrokerPodsPath}>
-            {t('broker')} {brokerName}
+          <BreadcrumbItem>
+            <Button
+              variant="link"
+              onClick={() => history.push(redirectBrokerPodsPath)}
+            >
+              {t('broker')} {brokerName}
+            </Button>
           </BreadcrumbItem>
-          <BreadcrumbItem to={redirectBrokerDetailsPath}>
-            {podName}
+          <BreadcrumbItem>
+            <Button
+              variant="link"
+              onClick={() => history.push(redirectBrokerDetailsPath)}
+            >
+              {podName}
+            </Button>
           </BreadcrumbItem>
-          <BreadcrumbItem to={redirectAddressPath}>
-            {t('addresses')}
+          <BreadcrumbItem>
+            <Button
+              variant="link"
+              onClick={() => history.push(redirectAddressPath)}
+            >
+              {t('addresses')}
+            </Button>
           </BreadcrumbItem>
           <BreadcrumbItem isActive>
             {t('address')} {name}

--- a/src/shared-components/BrokerDetailsBreadcrumb/BrokerDetailsBreadcrumb.tsx
+++ b/src/shared-components/BrokerDetailsBreadcrumb/BrokerDetailsBreadcrumb.tsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Button,
   Dropdown,
   DropdownItem,
   DropdownPosition,
@@ -88,11 +89,21 @@ const BrokerDetailsBreadcrumb: FC<BrokerDetailsBreadcrumbProps> = ({
       <Level>
         <LevelItem>
           <Breadcrumb className="pf-u-mb-md">
-            <BreadcrumbItem to={redirectBrokerPath}>
-              {t('brokers')}
+            <BreadcrumbItem>
+              <Button
+                variant="link"
+                onClick={() => history.push(redirectBrokerPath)}
+              >
+                {t('brokers')}
+              </Button>
             </BreadcrumbItem>
-            <BreadcrumbItem to={redirectBrokerPodsPath}>
-              {t('broker')} {name}
+            <BreadcrumbItem>
+              <Button
+                variant="link"
+                onClick={() => history.push(redirectBrokerPodsPath)}
+              >
+                {t('broker')} {name}
+              </Button>
             </BreadcrumbItem>
             <BreadcrumbItem isActive>{podName}</BreadcrumbItem>
           </Breadcrumb>

--- a/src/shared-components/BrokerPodsBreadcrumb/BrokerPodsBreadcrumb.tsx
+++ b/src/shared-components/BrokerPodsBreadcrumb/BrokerPodsBreadcrumb.tsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router-dom';
 import {
   Breadcrumb,
   BreadcrumbItem,
+  Button,
   Dropdown,
   DropdownItem,
   DropdownPosition,
@@ -85,7 +86,11 @@ const BrokerPodsBreadcrumb: FC<BrokerPodsBreadcrumbProps> = ({
       <Level>
         <LevelItem>
           <Breadcrumb className="pf-u-mb-md">
-            <BreadcrumbItem to={redirectPath}>{t('brokers')}</BreadcrumbItem>
+            <BreadcrumbItem>
+              <Button variant="link" onClick={() => history.push(redirectPath)}>
+                {t('brokers')}
+              </Button>
+            </BreadcrumbItem>
             <BreadcrumbItem isActive>
               {t('broker')} {name}
             </BreadcrumbItem>


### PR DESCRIPTION
Before, clicking on a link in the breadcrumb was taking a lot of time since it was making the web browser entirely reload the application. Now the links are using the history navigation to change page at a correct pace.