### PR TITLE
[NOISSUE] Improve UI layout for breadcrumbs and titles

### DIFF
--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -126,13 +126,13 @@ const BrokerDetailsPage: FC = () => {
         padding={{ default: 'noPadding' }}
         className="pf-c-page__main-tabs"
       >
-        <div className="pf-u-mt-md pf-u-ml-md pf-u-mb-md">
+        <div className="pf-u-mt-md pf-u-mb-md">
           <BrokerDetailsBreadcrumb
             name={brokerName}
             namespace={namespace}
             podName={podName}
           />
-          <Title headingLevel="h2">
+          <Title headingLevel="h2" className="pf-u-ml-md">
             {t('broker')} {brokerName} {t('/')} {podName}
           </Title>
         </div>

--- a/src/brokers/broker-pods/PodsList.container.tsx
+++ b/src/brokers/broker-pods/PodsList.container.tsx
@@ -73,9 +73,9 @@ const PodsContainer: FC = () => {
         padding={{ default: 'noPadding' }}
         className="pf-c-page__main-tabs"
       >
-        <div className="pf-u-mt-md pf-u-ml-md pf-u-mb-md">
+        <div className="pf-u-mt-md pf-u-mb-md">
           <BrokerPodsBreadcrumb name={name} namespace={namespace} />
-          <Title headingLevel="h2">
+          <Title headingLevel="h2" className="pf-u-ml-md">
             {t('broker')} {name}
           </Title>
         </div>

--- a/src/metrics/components/MetricsLayout/MetricsLayout.tsx
+++ b/src/metrics/components/MetricsLayout/MetricsLayout.tsx
@@ -24,7 +24,9 @@ export const MetricsLayout: FC<MetricsLayoutProps> = ({
         'pf-u-px-lg-on-xl pf-u-pt-sm-on-xl pf-u-pb-lg-on-xl pf-u-px-md pf-u-pb-md'
       }
     >
-      <Title headingLevel="h2">Metrics</Title>
+      <Title headingLevel="h2" className="pf-u-ml-sm pf-u-mb-md">
+        Metrics
+      </Title>
       <Grid hasGutter>
         <GridItem>{metricsActions}</GridItem>
         {(() => {


### PR DESCRIPTION
Adjusted layout by removing padding-left from the wrapper div and adding padding to the title for better alignment with breadcrumb. Applied PatternFly design for the Metrics title.