### PR TITLE
[#175] make changing project have an effect

### DIFF
--- a/src/brokers/add-broker/AddBroker.component.tsx
+++ b/src/brokers/add-broker/AddBroker.component.tsx
@@ -11,7 +11,6 @@ import {
 
 type AddBrokerProps = {
   onCreateBroker: (data?: K8sResourceCommon) => void;
-  namespace: string;
   notification: {
     title: string;
     variant: AlertVariant;
@@ -22,7 +21,6 @@ type AddBrokerProps = {
 const AddBroker: FC<AddBrokerProps> = ({
   onCreateBroker,
   notification,
-  namespace,
   isUpdate,
 }) => {
   const formValues = useContext(BrokerCreationFormState);
@@ -46,14 +44,12 @@ const AddBroker: FC<AddBrokerProps> = ({
         <FormView
           onCreateBroker={onCreateBroker}
           notification={notification}
-          targetNs={namespace}
           isUpdate={isUpdate}
         />
       )}
       {editorType === EditorType.YAML && (
         <YamlEditorView
           onCreateBroker={onCreateBroker}
-          namespace={namespace}
           initialResourceYAML={formValues.cr}
           notification={notification}
           isUpdate={isUpdate}

--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -10,6 +10,7 @@ import {
   newArtemisCRState,
   artemisCrReducer,
   AddBrokerResourceValues,
+  ArtemisReducerOperations,
 } from '../utils';
 
 export interface AddBrokerProps {
@@ -44,11 +45,19 @@ const AddBrokerPage: FC = () => {
       });
   };
 
+  const [prevNamespace, setPrevNamespace] = useState(namespace);
+  if (prevNamespace !== namespace) {
+    dispatch({
+      operation: ArtemisReducerOperations.setNamespace,
+      payload: namespace,
+    });
+    setPrevNamespace(namespace);
+  }
+
   return (
     <BrokerCreationFormState.Provider value={brokerModel}>
       <BrokerCreationFormDispatch.Provider value={dispatch}>
         <AddBroker
-          namespace={namespace}
           notification={notification}
           onCreateBroker={k8sCreateBroker}
           isUpdate={false}

--- a/src/brokers/add-broker/components/AddBrokerForm/FormView.tsx
+++ b/src/brokers/add-broker/components/AddBrokerForm/FormView.tsx
@@ -37,14 +37,12 @@ type FormViewProps = {
     title: string;
     variant: AlertVariant;
   };
-  targetNs: string;
   isUpdate: boolean;
 };
 
 export const FormView: FC<FormViewProps> = ({
   onCreateBroker,
   notification: serverNotification,
-  targetNs,
   isUpdate,
 }) => {
   const { t } = useTranslation();
@@ -56,6 +54,7 @@ export const FormView: FC<FormViewProps> = ({
 
   const formState = useContext(BrokerCreationFormState);
   const { cr } = useContext(BrokerCreationFormState);
+  const targetNs = cr.metadata.namespace;
   const dispatch = useContext(BrokerCreationFormDispatch);
 
   useEffect(() => {

--- a/src/brokers/add-broker/components/AddBrokerForm/YamlEditorView.tsx
+++ b/src/brokers/add-broker/components/AddBrokerForm/YamlEditorView.tsx
@@ -18,7 +18,6 @@ import YAML from 'yaml';
 
 export type YamlEditorViewProps = {
   onCreateBroker: (content: any) => void;
-  namespace: string;
   initialResourceYAML: K8sResourceCommon;
   notification: {
     title: string;
@@ -29,7 +28,6 @@ export type YamlEditorViewProps = {
 
 const YamlEditorView: FC<YamlEditorViewProps> = ({
   onCreateBroker,
-  namespace,
   notification,
   isUpdate,
 }) => {
@@ -37,6 +35,7 @@ const YamlEditorView: FC<YamlEditorViewProps> = ({
   const history = useHistory();
 
   const fromState = useContext(BrokerCreationFormState);
+  const namespace = fromState.cr.metadata.namespace;
   const dispatch = useContext(BrokerCreationFormDispatch);
 
   const [canCreateBroker, loadingAccessReview] = useAccessReview({

--- a/src/brokers/update-broker/UpdateBroker.container.tsx
+++ b/src/brokers/update-broker/UpdateBroker.container.tsx
@@ -19,8 +19,6 @@ const UpdateBrokerPage: FC = () => {
 
   //states
   const [notification, setNotification] = useState(defaultNotification);
-  //  const [initialBrokerValue, setInitialBrokerValue] =
-  //    useState<K8sResourceCommon>({});
   const [loading, setLoading] = useState<boolean>(false);
 
   const crState = getArtemisCRState(name, namespace);
@@ -82,7 +80,6 @@ const UpdateBrokerPage: FC = () => {
     <BrokerCreationFormState.Provider value={brokerModel}>
       <BrokerCreationFormDispatch.Provider value={dispatch}>
         <AddBroker
-          namespace={namespace}
           notification={notification}
           onCreateBroker={k8sUpdateBroker}
           isUpdate={true}

--- a/src/brokers/utils/add-broker.ts
+++ b/src/brokers/utils/add-broker.ts
@@ -866,6 +866,9 @@ const updateNamespace = (cr: ArtemisCR, newName: string) => {
   if (!cr.spec.acceptors) {
     return;
   }
+  if (!cr.spec.resourceTemplates) {
+    return;
+  }
   cr.spec.acceptors.forEach((acceptor) => {
     const rt = cr.spec.resourceTemplates.find(
       (rt) => rt.selector.name === certManagerSelector(cr, acceptor.name),


### PR DESCRIPTION
Before changing the project had no impact on the state of the CR. Now it does and when the user changes the value of the namespace the value gets propagated using the reducer.

fixes #175