### PR TITLE
[#177] custom ui element for other parameters

### DIFF
--- a/src/brokers/utils/add-broker.test.ts
+++ b/src/brokers/utils/add-broker.test.ts
@@ -186,7 +186,10 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations.setAcceptorOtherParams,
       payload: {
         name: 'acceptors0',
-        otherParams: 'aKey=aValue,bKey=bValue',
+        otherParams: new Map<string, string>([
+          ['aKey', 'aValue'],
+          ['bKey', 'bValue'],
+        ]),
       },
     });
     expect(newState2.cr.spec.brokerProperties).toContain(
@@ -199,7 +202,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations.setAcceptorOtherParams,
       payload: {
         name: 'acceptors0',
-        otherParams: 'aKey=aValue',
+        otherParams: new Map<string, string>([['aKey', 'aValue']]),
       },
     });
     expect(newState3.cr.spec.brokerProperties).toContain(
@@ -377,7 +380,10 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations.setConnectorOtherParams,
       payload: {
         name: 'connectors0',
-        otherParams: 'aKey=aValue,bKey=bValue',
+        otherParams: new Map<string, string>([
+          ['aKey', 'aValue'],
+          ['bKey', 'bValue'],
+        ]),
       },
     });
     expect(newState2.cr.spec.brokerProperties).toContain(
@@ -390,7 +396,7 @@ describe('test the creation broker reducer', () => {
       operation: ArtemisReducerOperations.setConnectorOtherParams,
       payload: {
         name: 'connectors0',
-        otherParams: 'aKey=aValue',
+        otherParams: new Map<string, string>([['aKey', 'aValue']]),
       },
     });
     expect(newState3.cr.spec.brokerProperties).toContain(

--- a/src/configuration/acceptors-config.tsx
+++ b/src/configuration/acceptors-config.tsx
@@ -39,7 +39,6 @@ import {
   getConfigBindToAllInterfaces,
   getConfigFactoryClass,
   getConfigHost,
-  getConfigOtherParams,
   getConfigPort,
   getConfigProtocols,
   getConfigSSLEnabled,
@@ -54,6 +53,7 @@ import {
   ConfigTypeContext,
 } from './broker-models';
 import { ConfirmDeleteModal } from './confirmation-modal';
+import { OtherParameters } from './other-parameters';
 
 type PresetCautionProps = {
   configType: ConfigType;
@@ -212,7 +212,6 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
   const port = getConfigPort(cr, configType, configName);
   const host = getConfigHost(cr, configType, configName);
   const protocols = getConfigProtocols(cr, configType, configName);
-  const otherParams = getConfigOtherParams(cr, configType, configName);
   const isSSLEnabled = getConfigSSLEnabled(cr, configType, configName);
   const bindToAllInterfaces = getConfigBindToAllInterfaces(
     cr,
@@ -288,26 +287,6 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
         payload: {
           configName: configName,
           protocols: prot,
-        },
-      });
-    }
-  };
-  const onOtherParamsChange = (params: string) => {
-    if (configType === ConfigType.acceptors) {
-      dispatch({
-        operation: ArtemisReducerOperations.setAcceptorOtherParams,
-        payload: {
-          name: configName,
-          otherParams: params,
-        },
-      });
-    }
-    if (configType === ConfigType.connectors) {
-      dispatch({
-        operation: ArtemisReducerOperations.setConnectorOtherParams,
-        payload: {
-          name: configName,
-          otherParams: params,
         },
       });
     }
@@ -587,21 +566,19 @@ export const AcceptorConfigPage: FC<AcceptorProps> = ({
               onChange={onProtocolsChange}
             />
           </FormGroup>
-          <FormGroup
-            label="Other parameters"
-            fieldId="horizontal-form-otherParams"
-          >
-            <TextInput
-              value={otherParams}
-              isRequired
-              type="text"
-              id="horizontal-form-protocols"
-              aria-describedby="horizontal-form-protocols-helper"
-              name="horizontal-form-protocols"
-              onChange={onOtherParamsChange}
-            />
-          </FormGroup>
         </Grid>
+      </FormFieldGroup>
+      <FormFieldGroup
+        header={
+          <FormFieldGroupHeader
+            titleText={{
+              text: 'Other parameters',
+              id: 'field-group-configuration' + configName,
+            }}
+          />
+        }
+      >
+        <OtherParameters configName={configName} configType={configType} />
       </FormFieldGroup>
       {isSSLEnabled && (
         <FormFieldGroup

--- a/src/configuration/other-parameters.tsx
+++ b/src/configuration/other-parameters.tsx
@@ -1,0 +1,151 @@
+import {
+  ArtemisReducerOperations,
+  BrokerCreationFormDispatch,
+  BrokerCreationFormState,
+  getConfigOtherParams,
+} from '../brokers/utils';
+import { FC, useContext, useState } from 'react';
+import { ConfigType } from './broker-models';
+import {
+  Button,
+  InputGroup,
+  InputGroupText,
+  TextInput,
+} from '@patternfly/react-core';
+import { TrashIcon } from '@patternfly/react-icons';
+
+type ParamProps = {
+  paramKey: string;
+  paramValue: string;
+  configType: ConfigType;
+  configName: string;
+};
+
+const Param: FC<ParamProps> = ({
+  paramKey: key,
+  paramValue: value,
+  configType,
+  configName,
+}) => {
+  const { cr } = useContext(BrokerCreationFormState);
+  const otherParams = getConfigOtherParams(cr, configType, configName);
+  const dispatch = useContext(BrokerCreationFormDispatch);
+  const updateOtherParams = (prevKey: string, key: string, value: string) => {
+    const params = new Map(otherParams);
+    if (prevKey) {
+      params.delete(prevKey);
+    }
+    if (key) {
+      params.set(key, value);
+    }
+    if (configType === ConfigType.acceptors) {
+      dispatch({
+        operation: ArtemisReducerOperations.setAcceptorOtherParams,
+        payload: {
+          name: configName,
+          otherParams: params,
+        },
+      });
+    }
+    if (configType === ConfigType.connectors) {
+      dispatch({
+        operation: ArtemisReducerOperations.setConnectorOtherParams,
+        payload: {
+          name: configName,
+          otherParams: params,
+        },
+      });
+    }
+  };
+  const deleteOtherParam = (key: string) => {
+    updateOtherParams(key, '', '');
+  };
+  const [newKey, setNewKey] = useState(key);
+  const [newValue, setNewValue] = useState(value);
+  return (
+    <InputGroup>
+      <TextInput value={newKey} onChange={(v) => setNewKey(v)} />
+      <InputGroupText>=</InputGroupText>
+      <TextInput value={newValue} onChange={(v) => setNewValue(v)} />
+      <Button
+        onClick={() => updateOtherParams(key, newKey, newValue)}
+        isDisabled={
+          newKey === '' ||
+          newValue === '' ||
+          (newKey === key && newValue === value)
+        }
+      >
+        update
+      </Button>
+      <Button
+        variant="plain"
+        aria-label="Remove"
+        onClick={() => deleteOtherParam(key)}
+      >
+        <TrashIcon />
+      </Button>
+    </InputGroup>
+  );
+};
+
+type OtherParametersProps = {
+  configType: ConfigType;
+  configName: string;
+};
+
+export const OtherParameters: FC<OtherParametersProps> = ({
+  configType,
+  configName,
+}) => {
+  const { cr } = useContext(BrokerCreationFormState);
+  const otherParams = getConfigOtherParams(cr, configType, configName);
+  let newParamSuffix = 0;
+  const newParamBaseName = 'key';
+  while (otherParams.has(newParamBaseName + newParamSuffix)) {
+    newParamSuffix += 1;
+  }
+  const dispatch = useContext(BrokerCreationFormDispatch);
+  const addNewParam = (key: string, value: string) => {
+    const params = new Map(otherParams);
+    params.set(key, value);
+    if (configType === ConfigType.acceptors) {
+      dispatch({
+        operation: ArtemisReducerOperations.setAcceptorOtherParams,
+        payload: {
+          name: configName,
+          otherParams: params,
+        },
+      });
+    }
+    if (configType === ConfigType.connectors) {
+      dispatch({
+        operation: ArtemisReducerOperations.setConnectorOtherParams,
+        payload: {
+          name: configName,
+          otherParams: params,
+        },
+      });
+    }
+  };
+  return (
+    <>
+      {Array.from(otherParams).map(([key, value]) => (
+        <Param
+          key={configType + key + value}
+          paramKey={key}
+          paramValue={value}
+          configName={configName}
+          configType={configType}
+        />
+      ))}
+      <Button
+        variant="link"
+        onClick={() =>
+          addNewParam(newParamBaseName + newParamSuffix, 'placeholder')
+        }
+      >
+        Add an extra parameter
+      </Button>
+    </>
+  );
+};


### PR DESCRIPTION
Other parameters are a key value pair. The previous method was relying on a textfield for the user to enter these value as a comma separated list of properties. Now there's a ui component for it showing keys and values in separated text fields. The user can add a new entry, edit it at will and then update or delete it.

[Screencast from 2024-06-20 16-32-19.webm](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/86971992/08ec074b-9a9b-40c6-aa79-fa748ef3b46e)

fixes #177 