### PR TITLE
[#164] remove all alert() from the codebase

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -29,6 +29,7 @@ rules:
   react/prop-types: 'off'
   unused-imports/no-unused-imports-ts: 2
   no-console: 'error'
+  no-alert: 'error'
 settings:
   react:
     version: detect

--- a/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
+++ b/locales/en/plugin__activemq-artemis-self-provisioning-plugin.json
@@ -113,7 +113,6 @@
   "certification_details": "Certification Details",
   "from_secret": "from secret ",
   "pem": "PEM:",
-  "address": "Address",
   "select_issuer": "Issuer",
   "select_an_issuer": "Select an issuer",
   "select_an_issuer_help": "Only issuer part of a chain of trust do qualify (i.e the issuer must have a CA). Proceed to create a new chain of trust if needed..",
@@ -132,5 +131,9 @@
   "preset_warning": "This setting is linked to a preset, updating the value will result in the preset to be removed",
   "preset_caution": "This setting is linked to a preset, proceed with caution",
   "ingressHost": "Ingress Host",
-  "select_expose_mode": "Expose Mode"
+  "select_expose_mode": "Expose Mode",
+  "try_again": "Try again",
+  "login_failed": "Login Failed",
+  "login_failed_message": "Token invalid. Please check your credentials and try again.",
+  "show_cert_info": "only support tls format secret from cert-manager"
 }

--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -16,6 +16,12 @@ import {
   PageSectionVariants,
   Spinner,
   Alert,
+  Modal,
+  ModalVariant,
+  Button,
+  Text,
+  TextContent,
+  TextVariants,
 } from '@patternfly/react-core';
 import { useTranslation } from '../../i18n';
 import {
@@ -54,6 +60,7 @@ const BrokerDetailsPage: FC = () => {
   const [brokerDetails, setBrokerDetails] = useState<K8sResourceCommon>({});
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>('');
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState<boolean>(false);
   const [routes] = useK8sWatchResource<K8sResourceKind[]>({
     isList: true,
     groupVersionKind: {
@@ -87,6 +94,15 @@ const BrokerDetailsPage: FC = () => {
     k8sGetBroker();
   }, []);
 
+  const handleModalToggle = () => {
+    setIsErrorModalOpen(!isErrorModalOpen);
+  };
+
+  const handleTryAgain = () => {
+    setIsErrorModalOpen(false);
+    window.location.reload();
+  };
+
   const handleTabSelect = (_event: any, eventKey: string | number) => {
     searchParams.set('tab', eventKey.toString());
     history.push({ search: searchParams.toString() });
@@ -109,20 +125,33 @@ const BrokerDetailsPage: FC = () => {
     setPrevIsLoading(isLoading);
   }
   if (notify) {
-    if (isSucces) {
-      // TODO maybe use the OpenShift console notification system to let the
-      // user know that the login was a success?
-      alert(
-        'login successful ' + brokerDetails?.metadata?.name + ' token ' + token,
-      );
-    } else {
-      alert('login failed');
+    if (isError) {
+      setIsErrorModalOpen(true);
     }
     setNotify(false);
   }
 
   return (
     <AuthContext.Provider value={token}>
+      <Modal
+        variant={ModalVariant.small}
+        title={t('login_failed')}
+        titleIconVariant="danger"
+        isOpen={isErrorModalOpen}
+        onClose={handleModalToggle}
+        actions={[
+          <Button key="confirm" variant="primary" onClick={handleTryAgain}>
+            {t('try_again')}
+          </Button>,
+          <Button key="cancel" variant="link" onClick={handleModalToggle}>
+            {t('cancel')}
+          </Button>,
+        ]}
+      >
+        <TextContent>
+          <Text component={TextVariants.h6}>{t('login_failed_message')}</Text>
+        </TextContent>
+      </Modal>
       <PageSection
         variant={PageSectionVariants.light}
         padding={{ default: 'noPadding' }}

--- a/src/configuration/broker-models.tsx
+++ b/src/configuration/broker-models.tsx
@@ -3,6 +3,7 @@ import {
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
+  Alert,
   Button,
   Divider,
   Drawer,
@@ -64,6 +65,7 @@ import {
 import { CertificateDetailsModal } from './CertificateDetailsModal';
 import { AcceptorsConfigPage, PresetAlertPopover } from './acceptors-config';
 import { ConsoleConfigPage } from './console-config';
+import { t } from 'i18next';
 
 export const enum ConfigType {
   connectors = 'connectors',
@@ -674,7 +676,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
       return value.metadata.name === selectedSecret.toString();
     });
     if (theSecret.length !== 1) {
-      alert('only support tls format secret from cert-manager');
+      <Alert variant="info" title={t('show_cert_info')} />;
     }
     let pem: string;
     try {
@@ -691,7 +693,7 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
       setCertsToShowPem(pem);
       setIsCertDetailsModalOpen(true);
     } catch (err) {
-      alert('error decoding cert: ' + err.message);
+      <Alert variant="danger" title={err.message} />;
     }
   };
   const showCertTooltipRef = useRef<HTMLButtonElement>(null);


### PR DESCRIPTION
Removed all alert() calls from the codebase and replaced them with other user notification methods. Added a linter rule to forbid the use of alerts.

![Screenshot from 2024-06-24 13-50-14](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/assets/99248895/a8ab03a2-6882-4216-91e6-4d0f01cfeeca)
