### PR TITLE
version: remove the `v` in the version name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     tags:
-      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activemq-artemis-self-provisioning-plugin",
-  "version": "v0.1.0",
+  "version": "0.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -142,7 +142,7 @@
   },
   "consolePlugin": {
     "name": "activemq-artemis-self-provisioning-plugin",
-    "version": "v0.1.0",
+    "version": "0.1.0",
     "displayName": "Artemis Self Provisioning Plugin",
     "description": "Artemis Self Provisioning Plugin",
     "exposedModules": {


### PR DESCRIPTION
As discussed in https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/discussions/209 Move to a common version pattern with the operator. Updates also the release action.