### PR TITLE
release: pushing to quay was failing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: quay.io/${{ secrets.QUAY_NAMESPACE }}/${{env.IMAGE_NAME}}
+          image: ${{ env.IMAGE_NAME }}
           tags: dev.latest ${{ steps.vars.outputs.image_tag }}
           platforms: linux/amd64, linux/arm64
           context: .


### PR DESCRIPTION
The script was crashing most probably because of this:

```
Warning:
"quay.io/***/quay.io/***/activemq-artemis-self-provisioning-plugin" does not seem to be a valid registry path. The registry path should not contain more than 2 slashes. Refer to the Inputs section of the readme for naming image and registry.
```

The build from the ci works however, I'm taking the parametrisation from this workflow to apply it to the release workflow.