### PR TITLE
[#236] Adding merge rules in workflow

### DIFF
--- a/.github/workflows/merge-rules.yml
+++ b/.github/workflows/merge-rules.yml
@@ -1,0 +1,37 @@
+name: 'Pull Request Check'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get Commit Message
+        run: |
+          nlines=-1
+          for (( N=1; N<=${{github.event.pull_request.commits}}; N++ ))
+          do
+            prev_lines=$(($nlines+1))
+            nlines=0
+            while IFS= read -r line
+            do
+              nlines=$((nlines+1))
+              if (( $nlines == $prev_lines+1 )); then
+                if ! [[ "$line" =~ ^\[#[0-9]+\]\ .+$|^\[NO-ISSUE\]\ .+$ ]]; then
+                  echo "[ commit $N ]: Commit message should begin with [#nnn] or [NO-ISSUE], followed by a space."
+                  echo "but it is: $line"
+                  exit 1
+                fi
+              fi
+            done <<< $(git log --format=%B -n $N ${{github.event.pull_request.head.sha}})
+          done


### PR DESCRIPTION
The rules validates each pull request's commit message so that it should
* begin with an issue number like [#nnn]
* or begin with [NO-ISSUE] if no issues associated with it