### PR TITLE
Improve Button Alignment in the YAML Editor

### DIFF
--- a/src/shared-components/YamlEditorView/YamlEditorView.tsx
+++ b/src/shared-components/YamlEditorView/YamlEditorView.tsx
@@ -6,7 +6,6 @@ import {
   Page,
   ActionGroup,
   Button,
-  ButtonVariant,
 } from '@patternfly/react-core';
 import {
   CodeEditor,
@@ -48,11 +47,16 @@ const BrokerActionGroup: FC<BrokerActionGroupProps> = ({
   const { t } = useTranslation();
 
   return (
-    <ActionGroup>
-      <Button variant={ButtonVariant.primary} type="submit" onClick={onSubmit}>
+    <ActionGroup className="pf-u-mt-sm pf-u-mb-sm">
+      <Button
+        variant="primary"
+        type="submit"
+        onClick={onSubmit}
+        className="pf-u-ml-sm"
+      >
         {isUpdate ? t('apply') : t('create')}
       </Button>
-      <Button variant={ButtonVariant.secondary} onClick={onCancel}>
+      <Button variant="link" onClick={onCancel}>
         {t('cancel')}
       </Button>
     </ActionGroup>


### PR DESCRIPTION
Added margins between buttons and the ActionGroup div in the YAML editor to enhance clearer separation between the buttons and the surrounding div, to improve the UI alignment.

![Screenshot from 2024-07-16 18-24-39](https://github.com/user-attachments/assets/9209c8f5-6bc5-4bfa-a41d-1a9280eb2735)
