### PR TITLE
Update unit tests for BrokerPodsBreadcrumb component

### DIFF
--- a/src/brokers/broker-pods/components/BrokerPodsBreadcrumb/BrokerPodsBreadcrumb.test.tsx
+++ b/src/brokers/broker-pods/components/BrokerPodsBreadcrumb/BrokerPodsBreadcrumb.test.tsx
@@ -1,10 +1,36 @@
 import { MemoryRouter } from 'react-router-dom-v5-compat';
-import { screen, fireEvent, render, waitForI18n } from '../../../../test-utils';
+import {
+  screen,
+  fireEvent,
+  render,
+  waitForI18n,
+  waitFor,
+} from '../../../../test-utils';
 import { BrokerPodsBreadcrumb } from './BrokerPodsBreadcrumb';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { k8sDelete } from '@openshift-console/dynamic-plugin-sdk';
+import { AMQBrokerModel } from '../../../../k8s/models';
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  k8sDelete: jest.fn(),
+}));
 
 describe('BrokerPodsBreadcrumb', () => {
   const name = 'test-1';
   const namespace = 'test';
+  const navigate = jest.fn();
+  beforeEach(() => {
+    (useNavigate as jest.Mock).mockReturnValue(navigate);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('should render the component correctly', async () => {
     render(
@@ -23,6 +49,18 @@ describe('BrokerPodsBreadcrumb', () => {
     await waitForI18n(comp);
     expect(comp.getByText('brokers')).toBeInTheDocument();
     expect(comp.getByText(`broker ${name}`)).toBeInTheDocument();
+  });
+
+  it('should navigate back to BrokerList page when click on Brokers BreadcrumbItem', async () => {
+    const comp = render(
+      <MemoryRouter>
+        <BrokerPodsBreadcrumb name={name} namespace={namespace} />
+      </MemoryRouter>,
+    );
+    await waitForI18n(comp);
+
+    fireEvent.click(screen.getByText('brokers'));
+    expect(navigate).toHaveBeenCalledWith(`/k8s/ns/${namespace}/brokers`);
   });
 
   it('should redirect back to BrokerList page when namespace is all-namespaces', async () => {
@@ -51,5 +89,63 @@ describe('BrokerPodsBreadcrumb', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     fireEvent.click(toggle);
     expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('should open and close the delete broker modal', async () => {
+    const comp = render(
+      <MemoryRouter>
+        <BrokerPodsBreadcrumb name={name} namespace={namespace} />
+      </MemoryRouter>,
+    );
+    await waitForI18n(comp);
+
+    fireEvent.click(screen.getByTestId('broker-toggle-kebab'));
+    fireEvent.click(screen.getByText('delete_broker'));
+    expect(screen.getByText('delete_modal_instance_title')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('cancel'));
+    await waitFor(() =>
+      expect(
+        screen.queryByText('delete_modal_instance_title'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should navigate to the UpdateBrokerPage when onclick on Edit Broker button', async () => {
+    const comp = render(
+      <MemoryRouter>
+        <BrokerPodsBreadcrumb name={name} namespace={namespace} />
+      </MemoryRouter>,
+    );
+    await waitForI18n(comp);
+
+    fireEvent.click(screen.getByTestId('broker-toggle-kebab'));
+    fireEvent.click(screen.getByText('edit_broker'));
+    expect(navigate).toHaveBeenCalledWith(
+      `/k8s/ns/${namespace}/edit-broker/${name}`,
+    );
+  });
+
+  it('should delete broker and navigate to the brokers list', async () => {
+    (k8sDelete as jest.Mock).mockResolvedValue({});
+    const comp = render(
+      <MemoryRouter>
+        <BrokerPodsBreadcrumb name={name} namespace={namespace} />
+      </MemoryRouter>,
+    );
+    await waitForI18n(comp);
+
+    fireEvent.click(screen.getByTestId('broker-toggle-kebab'));
+    fireEvent.click(screen.getByText('delete_broker'));
+    await waitFor(() => screen.getByText('delete'));
+    fireEvent.click(screen.getByText('delete'));
+
+    await waitFor(() => {
+      expect(k8sDelete).toHaveBeenCalledWith({
+        model: AMQBrokerModel,
+        resource: { metadata: { name, namespace: namespace } },
+      });
+      expect(navigate).toHaveBeenCalledWith(`/k8s/ns/${namespace}/brokers`);
+    });
   });
 });


### PR DESCRIPTION
Added more unit tests to cover all edge cases
improved test coverage for BrokerPodsBreadCrumb component

![Screenshot from 2024-07-29 18-56-09](https://github.com/user-attachments/assets/7df8390e-1771-4719-8b8d-e23b4cef53e2)
