### PR TITLE
[NO-ISSUE] refactor how we login to jolokia

### DIFF
--- a/src/addresses/address-details/AddressDetails.component.tsx
+++ b/src/addresses/address-details/AddressDetails.component.tsx
@@ -15,7 +15,7 @@ import {
 import { useTranslation } from '../../i18n/i18n';
 import { useJolokiaServiceReadAddressAttributes } from '../../openapi/jolokia/queries';
 import { AddressDetailsRow } from './AddressDetailsRow';
-import { AuthContext } from '../../jolokia/customHooks';
+import { AuthContext } from '../../jolokia/context';
 
 type AddressDetailsTableProps = {
   name: string;
@@ -56,7 +56,7 @@ const AddressDetails: FC<AddressDetailsTableProps> = ({ name }) => {
     'UnRoutedMessageCount',
   ];
 
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const {
     data: readAddressAttrs,
     isSuccess,

--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -1,11 +1,4 @@
-import { FC, useState, useEffect } from 'react';
-import {
-  GreenCheckCircleIcon,
-  K8sResourceKind,
-  RedExclamationCircleIcon,
-  k8sGet,
-  useK8sWatchResource,
-} from '@openshift-console/dynamic-plugin-sdk';
+import { FC, useContext } from 'react';
 import {
   Tabs,
   Tab,
@@ -13,25 +6,10 @@ import {
   Title,
   PageSection,
   PageSectionVariants,
-  Spinner,
   Alert,
-  Modal,
-  ModalVariant,
-  Button,
-  Text,
-  TextContent,
-  TextVariants,
+  Spinner,
 } from '@patternfly/react-core';
 import { useTranslation } from '../../i18n/i18n';
-import { AMQBrokerModel } from '../../k8s/models';
-import { BrokerCR } from '../../k8s/types';
-import {
-  AuthContext,
-  useGetApiServerBaseUrl,
-  useJolokiaLogin,
-} from '../../jolokia/customHooks';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { OpenAPI as OpenAPIConfig } from '../../openapi/jolokia/requests/core/OpenAPI';
 import { ClientsContainer } from './components/Clients/Clients.container';
 import { AddressContainer } from './components/Addresses/Address.container';
 import { BrokerDetailsBreadcrumb } from './components/BrokerDetailsBreadcrumb/BrokerDetailsBreadcrumb';
@@ -48,9 +26,159 @@ import {
   useNavigate,
   useParams,
 } from 'react-router-dom-v5-compat';
+import { JolokiaAuthentication } from '../../jolokia/components/JolokiaAuthentication';
+import { UseGetBrokerCR } from '../../k8s/customHooks';
+import { AuthContext } from '../../jolokia/context';
+import { BrokerCR } from '../../k8s/types';
+import {
+  GreenCheckCircleIcon,
+  RedExclamationCircleIcon,
+} from '@openshift-console/dynamic-plugin-sdk';
 
-export const BrokerDetailsPage: FC = () => {
+type AuthenticatedPageContentPropType = {
+  brokerCr: BrokerCR;
+  brokerName: string;
+  podName: string;
+  namespace: string;
+  loading: boolean;
+  error: string;
+};
+const AuthenticatedPageContent: FC<AuthenticatedPageContentPropType> = ({
+  brokerCr,
+  brokerName,
+  namespace,
+  podName,
+  loading: loadingBrokerCr,
+  error: errorBrokerCr,
+}) => {
   const { t } = useTranslation();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const activeTabKey = searchParams.get('tab') || 'overview';
+  const navigate = useNavigate();
+  const handleTabSelect = (_event: any, eventKey: string | number) => {
+    searchParams.set('tab', eventKey.toString());
+    navigate({ search: searchParams.toString() });
+  };
+  const {
+    isSuccess: isSuccessToken,
+    isLoading: isLoadingToken,
+    isError: isErrorToken,
+  } = useContext(AuthContext);
+  return (
+    <PageSection
+      variant={PageSectionVariants.light}
+      padding={{ default: 'noPadding' }}
+      className="pf-c-page__main-tabs"
+    >
+      <div className="pf-u-mt-md pf-u-mb-md">
+        <BrokerDetailsBreadcrumb
+          name={brokerName}
+          namespace={namespace}
+          podName={podName}
+        />
+        <Title headingLevel="h2" className="pf-u-ml-md">
+          {t('broker')} {brokerName} {t('/')} {podName}
+        </Title>
+      </div>
+      {errorBrokerCr && <Alert variant="danger" title={errorBrokerCr} />}
+      <Tabs activeKey={activeTabKey} onSelect={handleTabSelect}>
+        <Tab
+          eventKey={'overview'}
+          title={<TabTitleText>{t('overview')}</TabTitleText>}
+        >
+          <OverviewContainer
+            name={brokerName}
+            namespace={namespace}
+            cr={brokerCr}
+            loading={loadingBrokerCr}
+          />
+        </Tab>
+        <Tab
+          eventKey={'clients'}
+          title={<TabTitleText>{t('clients')}</TabTitleText>}
+        >
+          <ClientsContainer />
+        </Tab>
+        <Tab
+          eventKey={'addresses'}
+          title={<TabTitleText>{t('addresses')}</TabTitleText>}
+        >
+          <AddressContainer />
+        </Tab>
+        {process.env.NODE_ENV === 'development' && (
+          <Tab
+            eventKey={'jolokiaTestPanel'}
+            title={
+              <TabTitleText>
+                {t('check-jolokia ')}
+                {isLoadingToken && (
+                  <Spinner size="sm" aria-label="connecting to jolokia" />
+                )}
+                {isSuccessToken && (
+                  <GreenCheckCircleIcon title="Jolokia connected" />
+                )}
+                {isErrorToken && (
+                  <RedExclamationCircleIcon title="Jolokia connection failed" />
+                )}
+              </TabTitleText>
+            }
+          >
+            <JolokiaTestPanel />
+            <br />
+          </Tab>
+        )}
+        {process.env.NODE_ENV === 'development' && (
+          <Tab
+            eventKey={'jolokia-details'}
+            title={
+              <TabTitleText>
+                {t('jolokia-details')}
+                {isLoadingToken && (
+                  <Spinner size="sm" aria-label="connecting to jolokia" />
+                )}
+                {isSuccessToken && (
+                  <GreenCheckCircleIcon title="Jolokia connected" />
+                )}
+                {isErrorToken && (
+                  <RedExclamationCircleIcon title="Jolokia connection failed" />
+                )}
+              </TabTitleText>
+            }
+          >
+            <Tabs defaultActiveKey={0}>
+              <Tab
+                eventKey={0}
+                title={<TabTitleText>{t('broker')}</TabTitleText>}
+              >
+                <JolokiaBrokerDetails />
+              </Tab>
+              <Tab
+                eventKey={1}
+                title={<TabTitleText>{t('addresses')}</TabTitleText>}
+              >
+                <JolokiaAddressDetails />
+              </Tab>
+              <Tab
+                eventKey={2}
+                title={<TabTitleText>{t('acceptors')}</TabTitleText>}
+              >
+                <JolokiaAcceptorDetails />
+              </Tab>
+              <Tab
+                eventKey={3}
+                title={<TabTitleText>{t('queues')}</TabTitleText>}
+              >
+                <JolokiaQueueDetails />
+              </Tab>
+            </Tabs>
+          </Tab>
+        )}
+      </Tabs>
+    </PageSection>
+  );
+};
+export const BrokerDetailsPage: FC = () => {
   const {
     ns: namespace,
     brokerName,
@@ -60,223 +188,25 @@ export const BrokerDetailsPage: FC = () => {
     brokerName?: string;
     podName?: string;
   }>();
-  const [brokerDetails, setBrokerDetails] = useState<BrokerCR>({});
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string>('');
-  const [isErrorModalOpen, setIsErrorModalOpen] = useState<boolean>(false);
-  const [routes] = useK8sWatchResource<K8sResourceKind[]>({
-    isList: true,
-    groupVersionKind: {
-      group: 'route.openshift.io',
-      kind: 'Route',
-      version: 'v1',
-    },
-    namespaced: true,
-  });
 
-  const location = useLocation();
-  const navigate = useNavigate();
-  const searchParams = new URLSearchParams(location.search);
-  const activeTabKey = searchParams.get('tab') || 'overview';
-
-  const k8sGetBroker = () => {
-    setLoading(true);
-    k8sGet({ model: AMQBrokerModel, name: brokerName, ns: namespace })
-      .then((broker: K8sResourceKind) => {
-        setBrokerDetails(broker as BrokerCR);
-      })
-      .catch((e) => {
-        setError(e.message);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  };
-
-  useEffect(() => {
-    k8sGetBroker();
-  }, []);
-
-  const handleModalToggle = () => {
-    setIsErrorModalOpen(!isErrorModalOpen);
-  };
-
-  const handleTryAgain = () => {
-    setIsErrorModalOpen(false);
-    window.location.reload();
-  };
-
-  const handleTabSelect = (_event: any, eventKey: string | number) => {
-    searchParams.set('tab', eventKey.toString());
-    navigate({ search: searchParams.toString() });
-  };
+  const { brokerCr, isLoading, error } = UseGetBrokerCR(brokerName, namespace);
 
   const podOrdinal = parseInt(podName.replace(brokerName + '-ss-', ''));
 
-  const { token, isSucces, isLoading, isError, source } = useJolokiaLogin(
-    brokerDetails,
-    routes,
-    podOrdinal,
-  );
-
-  const [prevIsLoading, setPrevIsLoading] = useState(isLoading);
-  const [notify, setNotify] = useState(false);
-  if (prevIsLoading !== isLoading) {
-    if (!isLoading && source === 'api') {
-      setNotify(true);
-    }
-    setPrevIsLoading(isLoading);
-  }
-  if (notify) {
-    if (isError) {
-      setIsErrorModalOpen(true);
-    }
-    setNotify(false);
-  }
-
   return (
-    <AuthContext.Provider value={token}>
-      <Modal
-        variant={ModalVariant.small}
-        title={t('login_failed')}
-        titleIconVariant="danger"
-        isOpen={isErrorModalOpen}
-        onClose={handleModalToggle}
-        actions={[
-          <Button key="confirm" variant="primary" onClick={handleTryAgain}>
-            {t('try_again')}
-          </Button>,
-          <Button key="cancel" variant="link" onClick={handleModalToggle}>
-            {t('cancel')}
-          </Button>,
-        ]}
-      >
-        <TextContent>
-          <Text component={TextVariants.h6}>{t('login_failed_message')}</Text>
-        </TextContent>
-      </Modal>
-      <PageSection
-        variant={PageSectionVariants.light}
-        padding={{ default: 'noPadding' }}
-        className="pf-c-page__main-tabs"
-      >
-        <div className="pf-u-mt-md pf-u-mb-md">
-          <BrokerDetailsBreadcrumb
-            name={brokerName}
-            namespace={namespace}
-            podName={podName}
-          />
-          <Title headingLevel="h2" className="pf-u-ml-md">
-            {t('broker')} {brokerName} {t('/')} {podName}
-          </Title>
-        </div>
-        {error && <Alert variant="danger" title={error} />}
-        <Tabs activeKey={activeTabKey} onSelect={handleTabSelect}>
-          <Tab
-            eventKey={'overview'}
-            title={<TabTitleText>{t('overview')}</TabTitleText>}
-          >
-            <OverviewContainer
-              name={brokerName}
-              namespace={namespace}
-              cr={brokerDetails}
-              loading={loading}
-            />
-          </Tab>
-          <Tab
-            eventKey={'clients'}
-            title={<TabTitleText>{t('clients')}</TabTitleText>}
-          >
-            <ClientsContainer />
-          </Tab>
-          <Tab
-            eventKey={'addresses'}
-            title={<TabTitleText>{t('addresses')}</TabTitleText>}
-          >
-            <AddressContainer />
-          </Tab>
-          {process.env.NODE_ENV === 'development' && (
-            <Tab
-              eventKey={'jolokiaTestPanel'}
-              title={
-                <TabTitleText>
-                  {t('check-jolokia ')}
-
-                  {isLoading && (
-                    <Spinner size="sm" aria-label="connecting to jolokia" />
-                  )}
-                  {isSucces && (
-                    <GreenCheckCircleIcon title="Jolokia connected" />
-                  )}
-                  {isError && (
-                    <RedExclamationCircleIcon title="Jolokia connection failed" />
-                  )}
-                </TabTitleText>
-              }
-            >
-              <JolokiaTestPanel />
-              <br />
-            </Tab>
-          )}
-          {process.env.NODE_ENV === 'development' && (
-            <Tab
-              eventKey={'jolokia-details'}
-              title={
-                <TabTitleText>
-                  {t('-jolokia-details')}
-
-                  {isLoading && (
-                    <Spinner size="sm" aria-label="connecting to jolokia" />
-                  )}
-                  {isSucces && (
-                    <GreenCheckCircleIcon title="Jolokia connected" />
-                  )}
-                  {isError && (
-                    <RedExclamationCircleIcon title="Jolokia connection failed" />
-                  )}
-                </TabTitleText>
-              }
-            >
-              <Tabs defaultActiveKey={0}>
-                <Tab
-                  eventKey={0}
-                  title={<TabTitleText>{t('broker')}</TabTitleText>}
-                >
-                  <JolokiaBrokerDetails />
-                </Tab>
-                <Tab
-                  eventKey={1}
-                  title={<TabTitleText>{t('addresses')}</TabTitleText>}
-                >
-                  <JolokiaAddressDetails />
-                </Tab>
-                <Tab
-                  eventKey={2}
-                  title={<TabTitleText>{t('acceptors')}</TabTitleText>}
-                >
-                  <JolokiaAcceptorDetails />
-                </Tab>
-                <Tab
-                  eventKey={3}
-                  title={<TabTitleText>{t('queues')}</TabTitleText>}
-                >
-                  <JolokiaQueueDetails />
-                </Tab>
-              </Tabs>
-            </Tab>
-          )}
-        </Tabs>
-      </PageSection>
-    </AuthContext.Provider>
+    <JolokiaAuthentication brokerCR={brokerCr} podOrdinal={podOrdinal}>
+      <AuthenticatedPageContent
+        brokerCr={brokerCr}
+        brokerName={brokerName}
+        podName={podName}
+        namespace={namespace}
+        loading={isLoading}
+        error={error}
+      />
+    </JolokiaAuthentication>
   );
 };
 
 export const App: FC = () => {
-  OpenAPIConfig.BASE = useGetApiServerBaseUrl();
-  const querClient = new QueryClient();
-  return (
-    <QueryClientProvider client={querClient}>
-      <BrokerDetailsPage />
-    </QueryClientProvider>
-  );
+  return <BrokerDetailsPage />;
 };

--- a/src/brokers/broker-details/components/Addresses/Address.container.tsx
+++ b/src/brokers/broker-details/components/Addresses/Address.container.tsx
@@ -1,10 +1,10 @@
 import { FC, useContext } from 'react';
 import { Addresses } from './Address.component';
-import { AuthContext } from '../../../../jolokia/customHooks';
+import { AuthContext } from '../../../../jolokia/context';
 import { useJolokiaServiceGetAddresses } from '../../../../openapi/jolokia/queries';
 
 const AddressContainer: FC = () => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
 
   const { data: addresses, isSuccess } = useJolokiaServiceGetAddresses({
     jolokiaSessionId: authToken,

--- a/src/brokers/broker-details/components/Addresses/AddressRow.tsx
+++ b/src/brokers/broker-details/components/Addresses/AddressRow.tsx
@@ -6,7 +6,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Address } from '../../../../openapi/jolokia/requests';
 import { useJolokiaServiceReadAddressAttributes } from '../../../../openapi/jolokia/queries';
-import { AuthContext } from '../../../../jolokia/customHooks';
+import { AuthContext } from '../../../../jolokia/context';
 import { Link } from 'react-router-dom-v5-compat';
 
 export type AddressRowProps = RowProps<Address> & {
@@ -19,7 +19,7 @@ export const AddressRow: FC<AddressRowProps> = ({
   columns,
 }) => {
   const { name } = obj;
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const { data: routingTypes, isSuccess } =
     useJolokiaServiceReadAddressAttributes({
       jolokiaSessionId: authToken,

--- a/src/brokers/broker-details/components/JolokiaDevComponents.tsx
+++ b/src/brokers/broker-details/components/JolokiaDevComponents.tsx
@@ -42,7 +42,7 @@ import {
 } from '../../../openapi/jolokia/requests';
 import { useQuery } from '@tanstack/react-query';
 import { Signatures } from '../../../openapi/jolokia/requests/models/Signatures';
-import { AuthContext } from '../../../jolokia/customHooks';
+import { AuthContext } from '../../../jolokia/context';
 
 function getApiHost(): string {
   return process.env.NODE_ENV === 'production'
@@ -69,7 +69,7 @@ export const SignatureSubForm: FC<SignatureSubFormType> = ({
   name,
   signature,
 }) => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const [formValues, setFormvalues] = useState<Record<string, string>>({});
   const update = (name: string, value: string) => {
     const newFormValues = { ...formValues };
@@ -208,7 +208,7 @@ export const FetchAttr: FC<DisplayDetailsType> = ({
   acceptor,
   queue,
 }) => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const [formSelectValue, setFormSelectValue] = useState('');
 
   const onChange = (value: string) => {
@@ -299,7 +299,7 @@ export const FetchAttr: FC<DisplayDetailsType> = ({
 };
 
 export const JolokiaBrokerDetails: FC = () => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
 
   const { data: brokers, isSuccess: brokersSuccess } =
     useJolokiaServiceGetBrokers({ jolokiaSessionId: authToken });
@@ -327,7 +327,7 @@ export const JolokiaBrokerDetails: FC = () => {
 };
 
 export const JolokiaAddressDetails: FC = () => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const [selectedAddress, setSelectedAddress] = useState('');
 
   const { data: addresses, isSuccess: addressesSuccess } =
@@ -380,7 +380,7 @@ export const JolokiaAddressDetails: FC = () => {
 };
 
 export const JolokiaAcceptorDetails: FC = () => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const [selectedAcceptor, setSelectedAcceptor] = useState('');
 
   const { data: acceptors, isSuccess: isAcceptorsSuccess } =
@@ -433,7 +433,7 @@ export const JolokiaAcceptorDetails: FC = () => {
 };
 
 export const JolokiaQueueDetails: FC = () => {
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
   const [selectedQueue, setSelectesQueue] = useState('');
 
   const { data: queues, isSuccess: isQueueSuccess } =
@@ -489,7 +489,7 @@ const JolokiaTestPanel: FC = () => {
   const [jolokiaTestResult, setJolokiaTestResult] = useState('Result:');
   const [requestError, setRequestError] = useState(false);
 
-  const authToken = useContext(AuthContext);
+  const { token: authToken } = useContext(AuthContext);
 
   const setError = (error: string) => {
     setJolokiaTestResult(error);

--- a/src/jolokia/components/JolokiaAuthentication.tsx
+++ b/src/jolokia/components/JolokiaAuthentication.tsx
@@ -1,0 +1,87 @@
+import { FC, useState } from 'react';
+import { OpenAPI as OpenAPIConfig } from '../../openapi/jolokia/requests/core/OpenAPI';
+import {
+  useGetApiServerBaseUrl,
+  useJolokiaLogin,
+} from '../../jolokia/customHooks';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthContext } from '../context';
+import { BrokerCR } from '../../k8s/types';
+import {
+  Button,
+  Modal,
+  ModalVariant,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { useTranslation } from '../../i18n/i18n';
+
+type JolokiaPropTypes = {
+  brokerCR: BrokerCR;
+  podOrdinal: number;
+};
+
+const Authentication: FC<JolokiaPropTypes> = ({
+  children,
+  brokerCR,
+  podOrdinal,
+}) => {
+  const jolokiaLogin = useJolokiaLogin(brokerCR, podOrdinal);
+  const handleModalToggle = () => {
+    setIsErrorModalOpen(!isErrorModalOpen);
+  };
+
+  const handleTryAgain = () => {
+    setIsErrorModalOpen(false);
+    window.location.reload();
+  };
+  const [isErrorModalOpen, setIsErrorModalOpen] = useState<boolean>(false);
+  const [hasNotified, setHasNotified] = useState(false);
+
+  if (!hasNotified && jolokiaLogin.isError && jolokiaLogin.source === 'api') {
+    setIsErrorModalOpen(true);
+    setHasNotified(true);
+  }
+  const { t } = useTranslation();
+  return (
+    <AuthContext.Provider value={jolokiaLogin}>
+      <Modal
+        variant={ModalVariant.small}
+        title={t('login_failed')}
+        titleIconVariant="danger"
+        isOpen={isErrorModalOpen}
+        onClose={handleModalToggle}
+        actions={[
+          <Button key="confirm" variant="primary" onClick={handleTryAgain}>
+            {t('try_again')}
+          </Button>,
+          <Button key="cancel" variant="link" onClick={handleModalToggle}>
+            {t('cancel')}
+          </Button>,
+        ]}
+      >
+        <TextContent>
+          <Text component={TextVariants.h6}>{t('login_failed_message')}</Text>
+        </TextContent>
+      </Modal>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const JolokiaAuthentication: FC<JolokiaPropTypes> = ({
+  children,
+  brokerCR,
+  podOrdinal,
+}) => {
+  OpenAPIConfig.BASE = useGetApiServerBaseUrl();
+  const querClient = new QueryClient();
+  return (
+    <QueryClientProvider client={querClient}>
+      <Authentication brokerCR={brokerCR} podOrdinal={podOrdinal}>
+        {children}
+      </Authentication>
+    </QueryClientProvider>
+  );
+};

--- a/src/jolokia/context.ts
+++ b/src/jolokia/context.ts
@@ -1,0 +1,19 @@
+import { createContext } from 'react';
+
+export type jolokiaLoginSource = 'api' | 'session';
+
+export type JolokiaLogin = {
+  isSuccess: boolean;
+  isLoading: boolean;
+  isError: boolean;
+  token: string;
+  source: jolokiaLoginSource;
+};
+
+export const AuthContext = createContext<JolokiaLogin>({
+  token: '',
+  isLoading: true,
+  isSuccess: false,
+  isError: false,
+  source: 'api',
+});

--- a/src/k8s/customHooks.ts
+++ b/src/k8s/customHooks.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { Ingress } from './types';
+import { BrokerCR, Ingress } from './types';
 import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
-import { IngressDomainModel } from './models';
+import { AMQBrokerModel, IngressDomainModel } from './models';
 
 export const UseGetIngressDomain = (): {
   clusterDomain: string;
@@ -33,4 +33,35 @@ export const UseGetIngressDomain = (): {
   }
 
   return { clusterDomain: domain, isLoading: loading, error: error };
+};
+
+export const UseGetBrokerCR = (
+  brokerName: string,
+  namespace: string,
+): { brokerCr: BrokerCR; isLoading: boolean; error: string } => {
+  const [brokerDetails, setBrokerDetails] = useState<BrokerCR>({});
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+
+  const k8sGetBroker = () => {
+    setLoading(true);
+    k8sGet({ model: AMQBrokerModel, name: brokerName, ns: namespace })
+      .then((broker: BrokerCR) => {
+        setBrokerDetails(broker as BrokerCR);
+      })
+      .catch((e) => {
+        setError(e.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  const [isFirstMount, setIsFirstMount] = useState(true);
+  if (isFirstMount) {
+    k8sGetBroker();
+    setIsFirstMount(false);
+  }
+
+  return { brokerCr: brokerDetails, isLoading: loading, error: error };
 };


### PR DESCRIPTION
To minimize code duplication, extract the jolokia login to a new component JolokiaAuthentification. This component does the login and creates a context for its children components.

Now a developer can use this pattern to ensure the component someComponent will get in a logged in context.

```typescript
const AuthenticatedComponent: FC = () => {
  const brokerName = 'someName';
  const namespace = 'someNamespace';
  const podOrdinal = 0;
  const { brokerCr } = UseGetBrokerCR(brokerName, namespace);
  return (
    <JolokiaAuthentification brokerCR={brokerCr} podOrdinal={podOrdinal}>
      <SomeComponent />
    </JolokiaAuthentification>
  );
}
```