### PR TITLE
[#269] remove the ingressDomain field

### DIFF
--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../reducers/7.12/reducer';
 import { AddBrokerResourceValues } from '../../reducers/7.12/import-types';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
+import { UseGetIngressDomain } from '../../k8s/customHooks';
 
 export interface AddBrokerProps {
   initialValues: AddBrokerResourceValues;
@@ -52,6 +53,16 @@ export const AddBrokerPage: FC = () => {
       payload: namespace,
     });
     setPrevNamespace(namespace);
+  }
+
+  const { clusterDomain, isLoading } = UseGetIngressDomain();
+  const [isDomainSet, setIsDomainSet] = useState(false);
+  if (!isLoading && !isDomainSet) {
+    dispatch({
+      operation: ArtemisReducerOperations.setIngressDomain,
+      payload: clusterDomain,
+    });
+    setIsDomainSet(true);
   }
 
   return (

--- a/src/k8s/customHooks.ts
+++ b/src/k8s/customHooks.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { Ingress } from './types';
+import { k8sGet } from '@openshift-console/dynamic-plugin-sdk';
+import { IngressDomainModel } from './models';
+
+export const UseGetIngressDomain = (): {
+  clusterDomain: string;
+  isLoading: boolean;
+  error: string;
+} => {
+  const [domain, setDomain] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string>('');
+
+  const k8sGetBroker = () => {
+    setLoading(true);
+    k8sGet({ model: IngressDomainModel, name: 'cluster' })
+      .then((ing: Ingress) => {
+        setDomain(ing.spec.domain);
+      })
+      .catch((e) => {
+        setError(e.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  };
+
+  const [isFirstMount, setIsFirstMount] = useState(true);
+  if (isFirstMount) {
+    k8sGetBroker();
+    setIsFirstMount(false);
+  }
+
+  return { clusterDomain: domain, isLoading: loading, error: error };
+};

--- a/src/k8s/models.ts
+++ b/src/k8s/models.ts
@@ -68,3 +68,14 @@ export const SecretModel: K8sModel = {
   namespaced: false,
   crd: true,
 };
+
+export const IngressDomainModel: K8sModel = {
+  apiGroup: 'config.openshift.io',
+  apiVersion: 'v1',
+  kind: 'Ingress',
+  label: 'ingress',
+  plural: 'ingresses',
+  labelPlural: 'ingresses',
+  abbr: 'I',
+  namespaced: false,
+};

--- a/src/k8s/types.ts
+++ b/src/k8s/types.ts
@@ -132,3 +132,14 @@ export type SecretResource = K8sResource & {
     'tls.key'?: string;
   };
 };
+
+export type Ingress = K8sResource & {
+  spec: {
+    domain: string;
+    loadBalancer: {
+      platform: {
+        type: string;
+      };
+    };
+  };
+};

--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -616,7 +616,11 @@ describe('test the creation broker reducer', () => {
     const stateWith1Acceptor = artemisCrReducer(initialState, {
       operation: ArtemisReducerOperations.addAcceptor,
     });
-    const stateWithPEM = artemisCrReducer(stateWith1Acceptor, {
+    const stateWithIngressDomain = artemisCrReducer(stateWith1Acceptor, {
+      operation: ArtemisReducerOperations.setIngressDomain,
+      payload: 'apps-crc.testing',
+    });
+    const stateWithPEM = artemisCrReducer(stateWithIngressDomain, {
       operation: ArtemisReducerOperations.activatePEMGenerationForAcceptor,
       payload: {
         acceptor: 'acceptors0',

--- a/src/reducers/7.12/reducer.ts
+++ b/src/reducers/7.12/reducer.ts
@@ -62,7 +62,7 @@ export const newArtemisCRState = (namespace: string): FormState => {
     spec: {
       adminUser: 'admin',
       adminPassword: 'admin',
-      ingressDomain: 'apps-crc.testing',
+      ingressDomain: '',
       console: {
         expose: true,
       },

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -183,20 +183,6 @@ export const FormView: FC<FormViewProps> = ({
                 plusBtnAriaLabel="plus"
               />
             </FormGroup>
-            <FormGroup label="ingressDomain" fieldId="horizontal-form-Domain">
-              <TextInput
-                label="Ingress Domain"
-                name={'ingressDomain'}
-                id={'ingressDomain'}
-                value={cr.spec?.ingressDomain}
-                onChange={(v) =>
-                  dispatch({
-                    operation: ArtemisReducerOperations.setIngressDomain,
-                    payload: v,
-                  })
-                }
-              />
-            </FormGroup>
             <FormGroup label="Broker Properties">
               <InputGroup>
                 <InputGroupText id="broker-version" className=".pf-u-w-initial">


### PR DESCRIPTION
The ingress domain can be retrieved from the cluster configuration instead of asking the user to fill in the information themselves. This removes a confusing field from the formview.

This resolves one of the feedback points from @brusdev during the plugin presentation.

fixes #269 