### PR TITLE
[#217] checking certManager with CRDs

### DIFF
--- a/src/addresses/address-details/AddressDetails.container.test.tsx
+++ b/src/addresses/address-details/AddressDetails.container.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitForI18n } from '../../test-utils';
 import { AddressDetailsPage } from './AddressDetails.container';
 import { useParams } from 'react-router-dom-v5-compat';
 import { JolokiaAuthentication } from '../../jolokia/components/JolokiaAuthentication';
-import { UseGetBrokerCR } from '../../k8s/customHooks';
+import { useGetBrokerCR } from '../../k8s/customHooks';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
@@ -14,7 +14,7 @@ jest.mock('react-router-dom-v5-compat', () => ({
 }));
 
 jest.mock('../../k8s/customHooks', () => ({
-  UseGetBrokerCR: jest.fn(),
+  useGetBrokerCR: jest.fn(),
 }));
 
 jest.mock('./AddressDetails.component', () => ({
@@ -26,7 +26,7 @@ jest.mock('./AddressDetailsBreadcrumb/AddressDetailsBreadcrumb', () => ({
 }));
 
 const mockUseParams = useParams as jest.Mock;
-const mockUseGetBrokerCR = UseGetBrokerCR as jest.Mock;
+const mockUseGetBrokerCR = useGetBrokerCR as jest.Mock;
 const mockUseK8sWatchResource = useK8sWatchResource as jest.Mock;
 
 describe('AddressDetailsPage', () => {

--- a/src/addresses/address-details/AddressDetails.container.tsx
+++ b/src/addresses/address-details/AddressDetails.container.tsx
@@ -11,7 +11,7 @@ import { AddressDetailsBreadcrumb } from './AddressDetailsBreadcrumb/AddressDeta
 
 import { useParams } from 'react-router-dom-v5-compat';
 import { JolokiaAuthentication } from '../../jolokia/components/JolokiaAuthentication';
-import { UseGetBrokerCR } from '../../k8s/customHooks';
+import { useGetBrokerCR } from '../../k8s/customHooks';
 
 export const AddressDetailsPage: FC = () => {
   const { t } = useTranslation();
@@ -27,7 +27,7 @@ export const AddressDetailsPage: FC = () => {
     podName?: string;
   }>();
 
-  const { brokerCr: brokerDetails, error: error } = UseGetBrokerCR(
+  const { brokerCr: brokerDetails, error: error } = useGetBrokerCR(
     brokerName,
     namespace,
   );

--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../reducers/7.12/reducer';
 import { AddBrokerResourceValues } from '../../reducers/7.12/import-types';
 import { useNavigate, useParams } from 'react-router-dom-v5-compat';
-import { UseGetIngressDomain } from '../../k8s/customHooks';
+import { useGetIngressDomain } from '../../k8s/customHooks';
 
 export interface AddBrokerProps {
   initialValues: AddBrokerResourceValues;
@@ -55,7 +55,7 @@ export const AddBrokerPage: FC = () => {
     setPrevNamespace(namespace);
   }
 
-  const { clusterDomain, isLoading } = UseGetIngressDomain();
+  const { clusterDomain, isLoading } = useGetIngressDomain();
   const [isDomainSet, setIsDomainSet] = useState(false);
   if (!isLoading && !isDomainSet) {
     dispatch({

--- a/src/brokers/broker-details/BrokerDetails.container.tsx
+++ b/src/brokers/broker-details/BrokerDetails.container.tsx
@@ -27,7 +27,7 @@ import {
   useParams,
 } from 'react-router-dom-v5-compat';
 import { JolokiaAuthentication } from '../../jolokia/components/JolokiaAuthentication';
-import { UseGetBrokerCR } from '../../k8s/customHooks';
+import { useGetBrokerCR } from '../../k8s/customHooks';
 import { AuthContext } from '../../jolokia/context';
 import { BrokerCR } from '../../k8s/types';
 import {
@@ -189,7 +189,7 @@ export const BrokerDetailsPage: FC = () => {
     podName?: string;
   }>();
 
-  const { brokerCr, isLoading, error } = UseGetBrokerCR(brokerName, namespace);
+  const { brokerCr, isLoading, error } = useGetBrokerCR(brokerName, namespace);
 
   const podOrdinal = parseInt(podName.replace(brokerName + '-ss-', ''));
 

--- a/src/brokers/update-broker/UpdateBroker.container.tsx
+++ b/src/brokers/update-broker/UpdateBroker.container.tsx
@@ -5,7 +5,7 @@ import { AddBroker } from '../add-broker/AddBroker.component';
 import { Loading } from '../../shared-components/Loading/Loading';
 import { AMQBrokerModel } from '../../k8s/models';
 import { BrokerCR } from '../../k8s/types';
-import { UseGetIngressDomain } from '../../k8s/customHooks';
+import { useGetIngressDomain } from '../../k8s/customHooks';
 import {
   ArtemisReducerOperations,
   BrokerCreationFormDispatch,
@@ -71,7 +71,7 @@ export const UpdateBrokerPage: FC = () => {
   }, [name]);
 
   const { clusterDomain, isLoading: isLoadingClusterDomain } =
-    UseGetIngressDomain();
+    useGetIngressDomain();
   const [isDomainSet, setIsDomainSet] = useState(false);
   if (!loadingBrokerCR && !isLoadingClusterDomain && !isDomainSet) {
     dispatch({

--- a/src/k8s/customHooks.ts
+++ b/src/k8s/customHooks.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { AMQBrokerModel, IngressDomainModel } from './models';
 import { BrokerCR, Ingress } from './types';
 
-export const UseGetIngressDomain = (): {
+export const useGetIngressDomain = (): {
   clusterDomain: string;
   isLoading: boolean;
   error: string;
@@ -35,7 +35,7 @@ export const UseGetIngressDomain = (): {
   return { clusterDomain: domain, isLoading: loading, error: error };
 };
 
-export const UseGetBrokerCR = (
+export const useGetBrokerCR = (
   brokerName: string,
   namespace: string,
 ): { brokerCr: BrokerCR; isLoading: boolean; error: string } => {

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
@@ -3,6 +3,7 @@ import {
   ButtonVariant,
   Card,
   CardBody,
+  CardFooter,
   CardTitle,
   Form,
   FormFieldGroup,
@@ -24,6 +25,8 @@ import {
   getCertManagerResourceTemplateFromAcceptor,
 } from '../../../../../../../reducers/7.12/reducer';
 import { SelectIssuerDrawer } from '../SelectIssuerDrawer/SelectIssuerDrawer';
+import { useHasCertManager } from '../../../../../../../k8s/customHooks';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 type PreconfigurationButtonProps = {
   acceptor: Acceptor;
 };
@@ -79,6 +82,10 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
     getCertManagerResourceTemplateFromAcceptor(cr, initialAcceptor) !==
     undefined;
   const [showCertManagerForm, setShowCertManagerForm] = useState(false);
+  const { hasCertManager, isLoading: isLoadingCertManagerAvailability } =
+    useHasCertManager();
+  const isCertMangerDependencySatisfied =
+    hasCertManager && !isLoadingCertManagerAvailability;
   return (
     <Modal
       variant={ModalVariant.medium}
@@ -114,19 +121,32 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
           <Card
             id="selectable-first-card"
             onClick={() => {
+              if (!isCertMangerDependencySatisfied) {
+                return;
+              }
               if (hasACertManagerAnnotation) {
                 return;
               }
               setShowCertManagerForm(!showCertManagerForm);
             }}
-            isSelectableRaised
+            isSelectableRaised={isCertMangerDependencySatisfied}
             isSelected={showCertManagerForm}
             hasSelectableInput
             isCompact
             style={{ 'max-width': '100%' } as CSSProperties}
-            isDisabledRaised={hasACertManagerAnnotation}
+            isDisabledRaised={
+              hasACertManagerAnnotation || !isCertMangerDependencySatisfied
+            }
           >
-            <CardTitle>{t('Annotate_an_acceptor_with_an_issuer')}</CardTitle>
+            <CardTitle>{t('Annotate_an_acceptor_with_an_issuer')} </CardTitle>
+            {!isCertMangerDependencySatisfied && (
+              <CardFooter>
+                <>
+                  <ExclamationTriangleIcon />
+                  {' Preset disabled as CertManager is missing'}
+                </>
+              </CardFooter>
+            )}
             <br />
             <CardBody>
               <SimpleListGroup title="Effects:">

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
@@ -43,6 +43,7 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { CertificateDetailsModal } from './CertificateDetailsModal/CertificateDetailsModal';
 import { PresetAlertPopover } from '../AcceptorsConfigPage/AcceptorConfigSection/AcceptorConfigPage/PresetAlertPopover/PresetAlertPopover';
 import { ConfigType } from '../ConfigurationPage';
+import { useHasCertManager } from '../../../../../k8s/customHooks';
 
 const secretGroupVersionKind = {
   group: 'core',
@@ -528,6 +529,10 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
     }
   };
 
+  const { hasCertManager, isLoading: isLoadingCertMgrPresence } =
+    useHasCertManager();
+  const certMgrFound = hasCertManager && !isLoadingCertMgrPresence;
+
   const onCreateTestCert = () => {
     setIsSecretGenerating(true);
 
@@ -541,13 +546,6 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
         'No cert-manager found\n' + 'please install cert-manager.',
       );
       return;
-    }
-    let certMgrFound = false;
-    for (let i = 0; i < certManagerDeployments?.length; i++) {
-      if (certManagerDeployments[i].metadata?.name === 'cert-manager') {
-        certMgrFound = true;
-        break;
-      }
     }
     if (!certMgrFound) {
       failedSecretGen(
@@ -723,14 +721,22 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
               >
                 <InfoCircleIcon size="sm" />
               </Button>
-              <Button
-                isDisabled={isSecretGenerating}
-                variant="secondary"
-                onClick={onCreateTestCert}
-                isLoading={isSecretGenerating}
-              >
-                {certGenMessage}
-              </Button>
+              {certMgrFound ? (
+                <Button
+                  isDisabled={isSecretGenerating}
+                  variant="secondary"
+                  onClick={onCreateTestCert}
+                  isLoading={isSecretGenerating}
+                >
+                  {certGenMessage}
+                </Button>
+              ) : (
+                <Tooltip content="Generation disabled: Install CertManager">
+                  <Button isAriaDisabled variant="secondary">
+                    {certGenMessage}
+                  </Button>
+                </Tooltip>
+              )}
             </InputGroup>
           </DrawerContentBody>
         </DrawerContent>


### PR DESCRIPTION
Update the cert-manager checking logic to use CRDs instead of checking if cert-manager is deployed in a particular namespace. This is giving better results because cert-manager could have been deployed in many different namespaces.


![image](https://github.com/user-attachments/assets/0209a617-167f-4de3-8ffc-18f70eb10890)

![image](https://github.com/user-attachments/assets/eb42407e-2b59-4798-96d6-675b5daf360d)


fixes #222 
fixes #217 