### PR TITLE
[#192] support multiple hosts for the PEM case

### DIFF
--- a/src/brokers/broker-details/components/Overview/Overview.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Overview.container.tsx
@@ -19,7 +19,7 @@ import {
   Spinner,
   Title,
 } from '@patternfly/react-core';
-import { FC, useState } from 'react';
+import { FC, useContext, useState } from 'react';
 import {
   getIssuerForAcceptor,
   getIssuerIngressHostForAcceptor,
@@ -32,6 +32,7 @@ import {
   SecretResource,
 } from '../../../../k8s/types';
 import { Metrics } from './Metrics/Metrics';
+import { AuthContext } from '../../../../jolokia/context';
 
 const useGetIssuerCa = (
   cr: BrokerCR,
@@ -106,8 +107,9 @@ const HelpConnectAcceptor: FC<HelperConnectAcceptorProps> = ({
   cr,
   acceptor,
 }) => {
+  const { podOrdinal } = useContext(AuthContext);
   const secret = useGetTlsSecret(cr, acceptor);
-  const ingressHost = getIssuerIngressHostForAcceptor(cr, acceptor);
+  const ingressHost = getIssuerIngressHostForAcceptor(cr, acceptor, podOrdinal);
   const [copied, setCopied] = useState(false);
 
   const clipboardCopyFunc = (text: string) => {

--- a/src/jolokia/context.ts
+++ b/src/jolokia/context.ts
@@ -8,6 +8,7 @@ export type JolokiaLogin = {
   isError: boolean;
   token: string;
   source: jolokiaLoginSource;
+  podOrdinal: number;
 };
 
 export const AuthContext = createContext<JolokiaLogin>({
@@ -16,4 +17,5 @@ export const AuthContext = createContext<JolokiaLogin>({
   isSuccess: false,
   isError: false,
   source: 'api',
+  podOrdinal: 0,
 });

--- a/src/jolokia/customHooks.ts
+++ b/src/jolokia/customHooks.ts
@@ -233,6 +233,7 @@ export const useJolokiaLogin = (
       isError: isErrorRequestApi,
       token: token,
       source: 'session',
+      podOrdinal: ordinal,
     };
   }
   return {
@@ -241,6 +242,7 @@ export const useJolokiaLogin = (
     isLoading: isLoginMutationLoading || isLoginMutationIdle,
     token: token,
     source: 'api',
+    podOrdinal: ordinal,
   };
 };
 


### PR DESCRIPTION
Add support for multiple hosts to be exposed via an ingress when the user selects several replicas. Each pod gets exposed and has its own url to get connected to.

The connectivity helper shows the url of the currently selected pod.

fixes #192