### PR TITLE
[#198] the yaml editor allows to enter new Lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "react-router-dom-v5-compat": "6.22.3",
     "sort-package-json": "^2.10.0",
     "style-loader": "^3.3.1",
+    "css-loader": "^6.7.1",
     "stylelint": "^15.3.0",
     "stylelint-config-prettier": "9.0.3",
     "stylelint-config-standard": "^31.0.0",

--- a/src/brokers/add-broker/AddBroker.component.test.tsx
+++ b/src/brokers/add-broker/AddBroker.component.test.tsx
@@ -1,0 +1,129 @@
+import { FC, useReducer } from 'react';
+import {
+  BrokerCreationFormDispatch,
+  BrokerCreationFormState,
+  artemisCrReducer,
+  newArtemisCRState,
+} from '../../reducers/7.12/reducer';
+import { fireEvent, render, screen } from '../../test-utils';
+import { AddBroker } from './AddBroker.component';
+import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useAccessReview: jest.fn(() => []),
+}));
+
+const mockUseAccessReview = useAccessReview as jest.Mock;
+
+const SimplifiedCreaterBrokerPage: FC = () => {
+  const onSubmit = () => {
+    return 0;
+  };
+  const onCancel = () => {
+    return 0;
+  };
+  const initialValues = newArtemisCRState('default');
+  const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
+  return (
+    <BrokerCreationFormState.Provider value={brokerModel}>
+      <BrokerCreationFormDispatch.Provider value={dispatch}>
+        <AddBroker onSubmit={onSubmit} onCancel={onCancel} />
+      </BrokerCreationFormDispatch.Provider>
+    </BrokerCreationFormState.Provider>
+  );
+};
+
+const SimplifiedUpdateBrokerPage: FC = () => {
+  const onSubmit = () => {
+    return 0;
+  };
+  const onCancel = () => {
+    return 0;
+  };
+  const reloadExisting = () => {
+    return 0;
+  };
+  const initialValues = newArtemisCRState('default');
+  const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
+  return (
+    <BrokerCreationFormState.Provider value={brokerModel}>
+      <BrokerCreationFormDispatch.Provider value={dispatch}>
+        <AddBroker
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+          isUpdatingExisting
+          reloadExisting={reloadExisting}
+        />
+      </BrokerCreationFormDispatch.Provider>
+    </BrokerCreationFormState.Provider>
+  );
+};
+
+describe('create broker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseAccessReview.mockReturnValue([true, false]);
+  });
+  it('clicking on cancel after making some changes displays a warning', async () => {
+    render(<SimplifiedCreaterBrokerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /plus/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(
+      screen.getByText(
+        "You are about to quit the editor, the broker won't get created",
+      ),
+    ).toBeInTheDocument();
+  });
+  it("clicking on cancel immediately after opening the editor shouldn't display a warning", async () => {
+    render(<SimplifiedCreaterBrokerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(
+      screen.queryByText(
+        "You are about to quit the editor, the broker won't get created",
+      ),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('update broker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseAccessReview.mockReturnValue([true, false]);
+  });
+  it('clicking on cancel after making some changes displays a warning', async () => {
+    render(<SimplifiedUpdateBrokerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /plus/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(
+      screen.queryByText(
+        'You are about to quit the editor, configuration that is not applied will be lost',
+      ),
+    ).toBeInTheDocument();
+  });
+  it("clicking on cancel immediately after opening the editor shouldn't display a warning", async () => {
+    render(<SimplifiedUpdateBrokerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(
+      screen.queryByText(
+        'You are about to quit the editor, configuration that is not applied will be lost',
+      ),
+    ).not.toBeInTheDocument();
+  });
+  it('clicking on reload after making some changes displays a warning', async () => {
+    render(<SimplifiedUpdateBrokerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /plus/i }));
+    fireEvent.click(screen.getByRole('button', { name: /reload/i }));
+    expect(
+      screen.queryByText('Upon reloading, these modifications will be lost.'),
+    ).toBeInTheDocument();
+  });
+  it("clicking on reload immediately after opening the editor shouldn't display a warning", async () => {
+    render(<SimplifiedUpdateBrokerPage />);
+    fireEvent.click(screen.getByRole('button', { name: /reload/i }));
+    expect(
+      screen.queryByText('Upon reloading, these modifications will be lost.'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/brokers/add-broker/AddBroker.component.tsx
+++ b/src/brokers/add-broker/AddBroker.component.tsx
@@ -1,68 +1,212 @@
-import { FC, useContext } from 'react';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { AlertVariant, Divider } from '@patternfly/react-core';
+import { FC, useContext, useState } from 'react';
+import {
+  ActionGroup,
+  Alert,
+  AlertVariant,
+  Button,
+  ButtonVariant,
+  Divider,
+  Form,
+  FormFieldGroup,
+  Modal,
+  ModalVariant,
+} from '@patternfly/react-core';
 import {
   ArtemisReducerOperations,
   BrokerCreationFormDispatch,
   BrokerCreationFormState,
   EditorType,
 } from '../../reducers/7.12/reducer';
-import { useLocation } from 'react-router-dom-v5-compat';
 import { FormView } from '../../shared-components/FormView/FormView';
-import { YamlEditorView } from '../../shared-components/YamlEditorView/YamlEditorView';
 import { EditorToggle } from './components/EditorToggle/EditorToggle';
+import { Loading } from '../../shared-components/Loading/Loading';
+import { useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+import { AMQBrokerModel } from '../../k8s/models';
+import { useTranslation } from '../../i18n/i18n';
+import { YamlEditorView } from '../../shared-components/YamlEditorView/YamlEditorView';
 
-type AddBrokerProps = {
-  onCreateBroker: (data?: K8sResourceCommon) => void;
-  notification: {
-    title: string;
-    variant: AlertVariant;
-  };
-  isUpdate?: boolean;
+type AddBrokerPropTypes = {
+  onSubmit: () => void;
+  onCancel: () => void;
+  isUpdatingExisting?: boolean;
+  reloadExisting?: () => void;
 };
 
-export const AddBroker: FC<AddBrokerProps> = ({
-  onCreateBroker,
-  notification,
-  isUpdate,
+export const AddBroker: FC<AddBrokerPropTypes> = ({
+  onSubmit,
+  onCancel: doQuit,
+  isUpdatingExisting,
+  reloadExisting,
 }) => {
   const formValues = useContext(BrokerCreationFormState);
   const dispatch = useContext(BrokerCreationFormDispatch);
-  const location = useLocation();
-  const params = new URLSearchParams(location.search);
-  const returnUrl = params.get('returnUrl') || '/k8s/all-namespaces/brokers';
 
   const { editorType } = formValues;
 
-  const onSelectEditorType = (editorType: EditorType) => {
-    dispatch({
-      operation: ArtemisReducerOperations.setEditorType,
-      payload: editorType,
-    });
-  };
+  const [userWantsToQuit, setUserWantsToQuit] = useState<boolean>(false);
+  const [userWantsToReload, setUserWantsToReload] = useState<boolean>(false);
 
+  const [pendingActionQuittingYAMLView, setPendingActionQuittingYAMLView] =
+    useState<'switch' | 'submit'>('switch');
+  const [wantsToQuitYamlView, setWantsToQuitYamlView] = useState(false);
+  const onSelectEditorType = (editorType: EditorType) => {
+    if (formValues.editorType === EditorType.YAML) {
+      if (editorType === EditorType.BROKER) {
+        setWantsToQuitYamlView(true);
+      }
+      setPendingActionQuittingYAMLView('switch');
+    } else {
+      dispatch({
+        operation: ArtemisReducerOperations.setEditorType,
+        payload: EditorType.YAML,
+      });
+    }
+  };
+  const [triggerDelayedSubmit, setTriggerDelayedSubmit] = useState(false);
+  const [prevTriggerDelayedSubmit, setPrevTriggerDelayedSubmit] =
+    useState(triggerDelayedSubmit);
+  const onQuittingYamlView = () => {
+    if (pendingActionQuittingYAMLView === 'switch') {
+      setWantsToQuitYamlView(false);
+      dispatch({
+        operation: ArtemisReducerOperations.setEditorType,
+        payload: EditorType.BROKER,
+      });
+    }
+    if (pendingActionQuittingYAMLView === 'submit') {
+      setWantsToQuitYamlView(false);
+      setTriggerDelayedSubmit(true);
+    }
+  };
+  if (triggerDelayedSubmit !== prevTriggerDelayedSubmit) {
+    if (triggerDelayedSubmit) {
+      setTriggerDelayedSubmit(false);
+      onSubmit();
+    }
+    setPrevTriggerDelayedSubmit(triggerDelayedSubmit);
+  }
+
+  const { t } = useTranslation();
+  const namespace = formValues.cr.metadata.namespace;
+  const [canCreateBroker, loadingAccessReview] = useAccessReview({
+    group: AMQBrokerModel.apiGroup,
+    resource: AMQBrokerModel.plural,
+    namespace,
+    verb: 'create',
+  });
+  if (loadingAccessReview) return <Loading />;
+  if (!canCreateBroker) {
+    return (
+      <Alert
+        variant={AlertVariant.custom}
+        title={t('broker_can_not_be_created')}
+        isInline
+      >
+        {t('you_do_not_have_write_access')}
+      </Alert>
+    );
+  }
   return (
     <>
+      <Modal
+        variant={ModalVariant.small}
+        title="Unsaved changes"
+        isOpen={userWantsToQuit}
+        onClose={() => setUserWantsToQuit(false)}
+        actions={[
+          <Button key="confirm" variant="primary" onClick={doQuit}>
+            Confirm
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setUserWantsToQuit(false)}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        You are about to quit the editor,{' '}
+        {isUpdatingExisting
+          ? 'configuration that is not applied will be lost'
+          : "the broker won't get created"}
+      </Modal>
+      <Modal
+        variant={ModalVariant.small}
+        title="Unsaved changes"
+        isOpen={userWantsToReload}
+        onClose={() => setUserWantsToReload(false)}
+        actions={[
+          <Button key="confirm" variant="primary" onClick={reloadExisting}>
+            Confirm
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setUserWantsToReload(false)}
+          >
+            Cancel
+          </Button>,
+        ]}
+      >
+        Upon reloading, these modifications will be lost.
+      </Modal>
       <Divider />
       <EditorToggle value={editorType} onChange={onSelectEditorType} />
       <Divider />
-      {editorType === EditorType.BROKER && (
-        <FormView
-          onCreateBroker={onCreateBroker}
-          notification={notification}
-          isUpdate={isUpdate}
-          returnUrl={returnUrl}
-        />
-      )}
+      {editorType === EditorType.BROKER && <FormView />}
       {editorType === EditorType.YAML && (
         <YamlEditorView
-          onCreateBroker={onCreateBroker}
-          initialResourceYAML={formValues.cr}
-          notification={notification}
-          isUpdate={isUpdate}
-          returnUrl={returnUrl}
+          isAskingPermissionToClose={wantsToQuitYamlView}
+          permissionGranted={onQuittingYamlView}
+          permissionDenied={() => setWantsToQuitYamlView(false)}
         />
       )}
+      <Form>
+        <FormFieldGroup>
+          <ActionGroup>
+            <Button
+              variant={ButtonVariant.primary}
+              onClick={() => {
+                if (formValues.editorType === EditorType.YAML) {
+                  setWantsToQuitYamlView(true);
+                  setPendingActionQuittingYAMLView('submit');
+                } else {
+                  onSubmit();
+                }
+              }}
+            >
+              {isUpdatingExisting ? 'Apply' : 'Create'}
+            </Button>
+            {isUpdatingExisting && (
+              <Button
+                variant={ButtonVariant.secondary}
+                onClick={() => {
+                  if (formValues.hasChanges) {
+                    setUserWantsToReload(true);
+                  } else {
+                    reloadExisting();
+                  }
+                }}
+              >
+                Reload
+              </Button>
+            )}
+            <Button
+              variant={ButtonVariant.link}
+              onClick={() => {
+                if (formValues.hasChanges) {
+                  setUserWantsToQuit(true);
+                } else {
+                  doQuit();
+                }
+              }}
+            >
+              Cancel
+            </Button>
+          </ActionGroup>
+        </FormFieldGroup>
+      </Form>
     </>
   );
 };

--- a/src/reducers/7.12/import-types.ts
+++ b/src/reducers/7.12/import-types.ts
@@ -4,5 +4,7 @@ import { EditorType } from './reducer';
 export interface AddBrokerResourceValues {
   shouldShowYAMLMessage?: boolean;
   editorType?: EditorType;
+  yamlHasUnsavedChanges?: boolean;
+  hasChanges?: boolean;
   cr?: BrokerCR;
 }

--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -1104,4 +1104,40 @@ describe('test the creation broker reducer', () => {
     });
     expect(stateExposeModeIngress.cr.spec.acceptors[0].expose).toBe(true);
   });
+  it('test setYamlHasUnsavedChanges,', () => {
+    const initialState = newArtemisCRState('namespace');
+    const updatedState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerOperations.setYamlHasUnsavedChanges,
+    });
+    expect(updatedState.yamlHasUnsavedChanges).toBe(true);
+    expect(updatedState.hasChanges).toBe(false);
+  });
+  it('test machine controlled model update resets the changed flags,', () => {
+    const initialState = newArtemisCRState('namespace');
+    const updatedState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerOperations.setModel,
+      payload: {
+        model: initialState.cr,
+        isSetByUser: false,
+      },
+    });
+    expect(updatedState.yamlHasUnsavedChanges).toBe(false);
+    expect(updatedState.hasChanges).toBe(false);
+  });
+  it('test user controlled model update updates the flags correctly', () => {
+    const initialState = newArtemisCRState('namespace');
+    let updatedState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerOperations.setYamlHasUnsavedChanges,
+    });
+    expect(updatedState.hasChanges).toBe(false);
+    updatedState = artemisCrReducer(updatedState, {
+      operation: ArtemisReducerOperations.setModel,
+      payload: {
+        model: initialState.cr,
+        isSetByUser: true,
+      },
+    });
+    expect(updatedState.yamlHasUnsavedChanges).toBe(false);
+    expect(updatedState.hasChanges).toBe(true);
+  });
 });

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -1,12 +1,5 @@
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  ActionGroup,
-  Alert,
-  AlertGroup,
-  AlertVariant,
   Banner,
-  Button,
-  ButtonVariant,
   Form,
   FormFieldGroup,
   FormGroup,
@@ -20,8 +13,7 @@ import {
   TextInput,
   InputGroupItem,
 } from '@patternfly/react-core';
-import { FC, useContext, useEffect, useState } from 'react';
-import { useTranslation } from '../../i18n/i18n';
+import { FC, useContext, useState } from 'react';
 import {
   ArtemisReducerOperations,
   BrokerCreationFormDispatch,
@@ -31,67 +23,12 @@ import {
   BrokerProperties,
   BrokerPropertiesList,
 } from './BrokerProperties/BrokerProperties';
-import { useNavigate } from 'react-router-dom-v5-compat';
 
-type FormViewProps = {
-  onCreateBroker: (formValues: K8sResourceCommon) => void;
-  notification: {
-    title: string;
-    variant: AlertVariant;
-  };
-  isUpdate: boolean;
-  returnUrl: string;
-};
-
-export const FormView: FC<FormViewProps> = ({
-  onCreateBroker,
-  notification: serverNotification,
-  isUpdate,
-  returnUrl,
-}) => {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const defaultNotification = { title: '', variant: AlertVariant.custom };
-
-  //states
-  const [notification, setNotification] = useState(defaultNotification);
-
+export const FormView: FC = () => {
   const formState = useContext(BrokerCreationFormState);
   const { cr } = useContext(BrokerCreationFormState);
   const targetNs = cr.metadata.namespace;
   const dispatch = useContext(BrokerCreationFormDispatch);
-
-  useEffect(() => {
-    setNotification(serverNotification);
-  }, [serverNotification]);
-
-  const validateFormFields = (formValues: K8sResourceCommon) => {
-    const name = formValues.metadata.name;
-    const regex =
-      /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/i;
-    if (!regex.test(name)) {
-      setNotification({
-        title: t('form_view_validation_info'),
-        variant: AlertVariant.danger,
-      });
-      return false;
-    } else {
-      setNotification({ title: 'ok', variant: AlertVariant.success });
-      return true;
-    }
-  };
-
-  const onSubmit = () => {
-    const isValid = validateFormFields(formState.cr);
-    if (isValid) {
-      onCreateBroker(formState.cr);
-      navigate(returnUrl);
-    }
-  };
-
-  const onCancel = () => {
-    navigate(returnUrl);
-  };
 
   const handleNameChange = (name: string) => {
     dispatch({
@@ -125,17 +62,6 @@ export const FormView: FC<FormViewProps> = ({
   return (
     <>
       <Form isHorizontal isWidthLimited>
-        {notification.title && (
-          <AlertGroup>
-            <Alert
-              data-test="add-broker-notification-form-view"
-              title={notification.title}
-              variant={notification.variant}
-              isInline
-              actionClose
-            />
-          </AlertGroup>
-        )}
         <FormFieldGroup>
           <Grid hasGutter md={6}>
             <FormGroup
@@ -244,22 +170,6 @@ export const FormView: FC<FormViewProps> = ({
               targetNs={targetNs}
             />
           )}
-        </FormFieldGroup>
-      </Form>
-      <Form>
-        <FormFieldGroup>
-          <ActionGroup>
-            <Button
-              variant={ButtonVariant.primary}
-              type="submit"
-              onClick={onSubmit}
-            >
-              {isUpdate ? t('apply') : t('create')}
-            </Button>
-            <Button variant={ButtonVariant.link} onClick={onCancel}>
-              {t('cancel')}
-            </Button>
-          </ActionGroup>
         </FormFieldGroup>
       </Form>
     </>

--- a/src/shared-components/YamlEditorView/YamlEditorView.css
+++ b/src/shared-components/YamlEditorView/YamlEditorView.css
@@ -1,0 +1,7 @@
+#reload-object{
+    display: none;
+}
+
+#cancel{
+    display: none;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,6 +3854,20 @@ css-functions-list@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.2.tgz#9a54c6dd8416ed25c1079cd88234e927526c1922"
   integrity sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ==
 
+css-loader@^6.7.1:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.11.0.tgz#33bae3bf6363d0a7c2cf9031c96c744ff54d85ba"
+  integrity sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==
+  dependencies:
+    icss-utils "^5.1.0"
+    postcss "^8.4.33"
+    postcss-modules-extract-imports "^3.1.0"
+    postcss-modules-local-by-default "^4.0.5"
+    postcss-modules-scope "^3.2.0"
+    postcss-modules-values "^4.0.0"
+    postcss-value-parser "^4.2.0"
+    semver "^7.5.4"
+
 css-select@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
@@ -5925,6 +5939,11 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+icss-utils@^5.0.0, icss-utils@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
+  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
 ignore@^3.3.3, ignore@^3.3.5:
   version "3.3.10"
@@ -8509,6 +8528,34 @@ postcss-media-query-parser@^0.2.3:
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
   integrity sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==
 
+postcss-modules-extract-imports@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz#b4497cb85a9c0c4b5aabeb759bb25e8d89f15002"
+  integrity sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==
+
+postcss-modules-local-by-default@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.5.tgz#f1b9bd757a8edf4d8556e8d0f4f894260e3df78f"
+  integrity sha512-6MieY7sIfTK0hYfafw1OMEG+2bg8Q1ocHCpoWLqOKj3JXlKu4G7btkmM/B7lFubYkYWmRSPLZi5chid63ZaZYw==
+  dependencies:
+    icss-utils "^5.0.0"
+    postcss-selector-parser "^6.0.2"
+    postcss-value-parser "^4.1.0"
+
+postcss-modules-scope@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.2.0.tgz#a43d28289a169ce2c15c00c4e64c0858e43457d5"
+  integrity sha512-oq+g1ssrsZOsx9M96c5w8laRmvEu9C3adDSjI8oTcbfkrTE8hx/zfyobUoWIxaKPO8bt6S62kxpw5GqypEw1QQ==
+  dependencies:
+    postcss-selector-parser "^6.0.4"
+
+postcss-modules-values@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
+  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
+  dependencies:
+    icss-utils "^5.0.0"
+
 postcss-reporter@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-reporter/-/postcss-reporter-5.0.0.tgz#a14177fd1342829d291653f2786efd67110332c3"
@@ -8568,12 +8615,20 @@ postcss-selector-parser@^6.0.13:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
+postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz#27ecb41fb0e3b6ba7a1ec84fff347f734c7929de"
+  integrity sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
 postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -8601,6 +8656,15 @@ postcss@^8.4.28:
   version "8.4.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.39.tgz#aa3c94998b61d3a9c259efa51db4b392e1bde0e3"
   integrity sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.1"
+    source-map-js "^1.2.0"
+
+postcss@^8.4.33:
+  version "8.4.45"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.45.tgz#538d13d89a16ef71edbf75d895284ae06b79e603"
+  integrity sha512-7KTLTdzdZZYscUc65XmjFiB73vBhBfbPztCYdUNvlaso9PrzjzcmjqBPR0lNGkcVlcO4BjiO5rK/qNz+XAen1Q==
   dependencies:
     nanoid "^3.3.7"
     picocolors "^1.0.1"
@@ -9581,6 +9645,11 @@ semver@^7.3.2, semver@^7.3.4, semver@^7.3.7, semver@^7.5.3, semver@^7.6.0:
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
   integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
+
+semver@^7.5.4:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
Previously the yaml editor wasn't allowing us to add new lines. This was because at each keystroke the yaml file was formated automatically, removing unecessary lines..
This meant that the user had to use tricks like copy&pasting to get to a state the wanted to have.

To fix that, this commits reverts back to using the resource editor provided by the console. It has several advantages:
* The use can edit the file as they want without bugs
* There's documentation included from the CRDs when hovering properties

The main drawback is that the user needs to click on save to save their changes to the model, then needs to click on apply to apply their config (either creating or updating)

fixes #198 