### PR TITLE
Generate unique port numbers for acceptors and connectors separately

### DIFF
--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -540,29 +540,29 @@ describe('test the creation broker reducer', () => {
     let newStateWithConnector = artemisCrReducer(initialState, {
       operation: ArtemisReducerOperations.addConnector,
     });
-    expect(newStateWithConnector.cr.spec.connectors[0].port).toBe(5559);
+    expect(newStateWithConnector.cr.spec.connectors[0].port).toBe(5555);
 
     //Add second connector
     newStateWithConnector = artemisCrReducer(initialState, {
       operation: ArtemisReducerOperations.addConnector,
     });
-    expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5560);
+    expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5556);
 
-    // Manually change the port of the second connector to 5561
+    // Manually change the port of the second connector to 5557
     newStateWithConnector = artemisCrReducer(newStateWithConnector, {
       operation: ArtemisReducerOperations.setConnectorPort,
       payload: {
         name: 'connectors1',
-        port: 5561,
+        port: 5557,
       },
     });
-    expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5561);
+    expect(newStateWithConnector.cr.spec.connectors[1].port).toBe(5557);
 
     //Add third connector
     newStateWithConnector = artemisCrReducer(newStateWithConnector, {
       operation: ArtemisReducerOperations.addConnector,
     });
-    expect(newStateWithConnector.cr.spec.connectors[2].port).toBe(5562);
+    expect(newStateWithConnector.cr.spec.connectors[2].port).toBe(5558);
   });
 
   it('test setConnectorProtocols', () => {


### PR DESCRIPTION
- Updated the logic to generate unique port numbers for `acceptors`and `connectors` separately.
- Updated unit test to verify the unique port assignment for both `acceptors` and `connectors` separately.

fixes: [#279](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/279)