### PR TITLE
The deployment size should be allowed to reach the value 0

### DIFF
--- a/src/reducers/7.12/reducer.test.ts
+++ b/src/reducers/7.12/reducer.test.ts
@@ -50,8 +50,8 @@ describe('test the creation broker reducer', () => {
     const newState = artemisCrReducer(initialState, {
       operation: ArtemisReducerOperations.decrementReplicas,
     });
-    // default size is 1 decrementing should result of a size of 1
-    expect(newState.cr.spec.deploymentPlan.size).toBe(1);
+    // default size is 1 decrementing should result of a size of 0
+    expect(newState.cr.spec.deploymentPlan.size).toBe(0);
     // set the number of replicas to 10 before decrementing so that the total
     // number should be 9
     const newState2 = artemisCrReducer(
@@ -64,6 +64,27 @@ describe('test the creation broker reducer', () => {
       },
     );
     expect(newState2.cr.spec.deploymentPlan.size).toBe(9);
+  });
+
+  it('tests that the deployment replicas value cannot be decremented below 0', () => {
+    const initialState = newArtemisCRState('namespace');
+    const newState = artemisCrReducer(initialState, {
+      operation: ArtemisReducerOperations.decrementReplicas,
+    });
+    // default size is 1 decrementing should result of a size of 0
+    expect(newState.cr.spec.deploymentPlan.size).toBe(0);
+    // Set the number of replicas to -1 and verify that the deployment replicas value cannot be decremented below 0.
+    // The number should be set to 0.
+    const newState2 = artemisCrReducer(
+      artemisCrReducer(newState, {
+        operation: ArtemisReducerOperations.setReplicasNumber,
+        payload: -1,
+      }),
+      {
+        operation: ArtemisReducerOperations.decrementReplicas,
+      },
+    );
+    expect(newState2.cr.spec.deploymentPlan.size).toBe(0);
   });
 
   it('test deleteAcceptor', () => {

--- a/src/reducers/7.12/reducer.ts
+++ b/src/reducers/7.12/reducer.ts
@@ -894,7 +894,7 @@ const updateIngressDomain = (cr: BrokerCR, newName: string) => {
 const updateDeploymentSize = (cr: BrokerCR, newSize: number) => {
   cr.spec.deploymentPlan.size = newSize;
   if (cr.spec.deploymentPlan.size < 1) {
-    cr.spec.deploymentPlan.size = 1;
+    cr.spec.deploymentPlan.size = 0;
   }
   // when the size changes, some annotations will need an update to
   // stay in sync

--- a/src/shared-components/FormView/FormView.tsx
+++ b/src/shared-components/FormView/FormView.tsx
@@ -160,7 +160,7 @@ export const FormView: FC<FormViewProps> = ({
             >
               <NumberInput
                 value={replicas}
-                min={1}
+                min={0}
                 max={1024}
                 onMinus={() =>
                   dispatch({


### PR DESCRIPTION
Updated the deployment size should be allowed to reach the value 0.

![Screenshot from 2024-09-02 18-30-48](https://github.com/user-attachments/assets/3d038f07-ca55-4677-aaff-8d6516435874)


fixes: [#276](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/276)
