### PR TITLE
fix: UI should be compatible with CRs that are containing empty arrays

### DIFF
--- a/src/brokers/broker-details/components/Overview/Overview.container.tsx
+++ b/src/brokers/broker-details/components/Overview/Overview.container.tsx
@@ -181,7 +181,7 @@ const ConnectivityHelper: FC<IssuerSecretsDownloaderProps> = ({ cr }) => {
         .map((acceptor) =>
           acceptor.sslSecret ? acceptor.sslSecret.endsWith('-ptls') : false,
         )
-        .reduce((acc, hasGeneratedSecrets) => acc || hasGeneratedSecrets)
+        .reduce((acc, hasGeneratedSecrets) => acc || hasGeneratedSecrets, false)
     : false;
   if (!oneAcceptorHasGeneratedSecrets) {
     return <></>;


### PR DESCRIPTION
This commit resolves a crash in the `ConnectivityHelper` component caused by calling the reduce() function on an empty array without an initial value. In cases where the `acceptors` array in the CR's spec is empty, the UI previously crashed due to the lack of an initial value in the reduce operation.

The fix ensures that the reduce function uses `false` as the initial value, making the UI compatible with CRs containing empty `acceptors` arrays.

fixes: [#219](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/219)