### PR TITLE
fix: Broker page refreshes automatically upon broker creation

### DIFF
--- a/src/k8s/models.ts
+++ b/src/k8s/models.ts
@@ -12,7 +12,7 @@ import {
 export const AMQBrokerModel: K8sModel = {
   apiGroup: AMQ_BROKER_APIGROUP,
   apiVersion: API_VERSION,
-  kind: 'ActiveMQArtemisList',
+  kind: 'ActiveMQArtemis',
   label: 'Broker',
   labelKey: 'Brokers',
   labelPlural: 'Brokers',


### PR DESCRIPTION
fixed the bug where the broker page refreshes automatically upon broker creation using `useK8sWatchResource` hook.


fixes: [#218](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/218)