### PR TITLE
[NO-ISSUE] post patternfly5 upgrade on cards

### DIFF
--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/AcceptorsConfigPage/AcceptorConfigSection/PresetButton/PresetButton.tsx
@@ -4,6 +4,7 @@ import {
   Card,
   CardBody,
   CardFooter,
+  CardHeader,
   CardTitle,
   Form,
   FormFieldGroup,
@@ -87,6 +88,17 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
     useHasCertManager();
   const isCertMangerDependencySatisfied =
     hasCertManager && !isLoadingCertManagerAvailability;
+  const onChange = (event: React.FormEvent<HTMLInputElement>) => {
+    if (event.currentTarget.id === 'certmanagerandingress') {
+      if (!isCertMangerDependencySatisfied) {
+        return;
+      }
+      if (hasACertManagerAnnotation) {
+        return;
+      }
+      setShowCertManagerForm(!showCertManagerForm);
+    }
+  };
   return (
     <Modal
       variant={ModalVariant.medium}
@@ -121,33 +133,30 @@ const AddPresetModal: FC<AddIssuerAnnotationModalProps> = ({
         >
           <Card
             id="selectable-first-card"
-            onClick={() => {
-              if (!isCertMangerDependencySatisfied) {
-                return;
-              }
-              if (hasACertManagerAnnotation) {
-                return;
-              }
-              setShowCertManagerForm(!showCertManagerForm);
-            }}
             isSelectable
             isSelected={showCertManagerForm}
-            hasSelectableInput
             isCompact
             style={{ 'max-width': '100%' } as CSSProperties}
-            isDisabled
-            tabIndex={0}
+            isDisabled={!isCertMangerDependencySatisfied}
           >
-            <CardTitle>{t('Annotate_an_acceptor_with_an_issuer')} </CardTitle>
-            {!isCertMangerDependencySatisfied && (
-              <CardFooter>
-                <>
-                  <ExclamationTriangleIcon />
-                  {' Preset disabled as CertManager is missing'}
-                </>
-              </CardFooter>
-            )}
-            <br />
+            <CardHeader
+              selectableActions={{
+                selectableActionId: 'certmanagerandingress',
+                name: 'certmanagerandingress',
+                variant: 'multiple',
+                onChange,
+              }}
+            >
+              <CardTitle>{t('Annotate_an_acceptor_with_an_issuer')} </CardTitle>
+              {!isCertMangerDependencySatisfied && (
+                <CardFooter>
+                  <>
+                    <ExclamationTriangleIcon />
+                    {' Preset disabled as CertManager is missing'}
+                  </>
+                </CardFooter>
+              )}
+            </CardHeader>
             <CardBody>
               <SimpleListGroup title="Effects:">
                 <SimpleList>

--- a/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
+++ b/src/shared-components/FormView/BrokerProperties/ConfigurationPage/CertSecretSelector/CertSecretSelector.tsx
@@ -545,12 +545,6 @@ export const CertSecretSelector: FC<CertSecretSelectorProps> = ({
       'cert mgr pods: ' + certManagerDeployments.length.toString(),
     );
 
-    if (certManagerDeployments.length === 0) {
-      failedSecretGen(
-        'No cert-manager found\n' + 'please install cert-manager.',
-      );
-      return;
-    }
     if (!certMgrFound) {
       failedSecretGen(
         'No cert-manager found\n' + 'please install cert-manager.',


### PR DESCRIPTION
After the upgrade to pf5 got complete, and after the fix preventing some CSS to load completely was landed in the console, there was still some work to be done to migrate the cards to the new PF5 ways of doing things.
Also a check was left in the cert generation preventing certs to be generated even though cert-manager was installed.