### PR TITLE
[#294] Added 'Brokers' entry within the Workloads section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ This will run the OpenShift console in a container connected to the cluster
 you've logged into. The plugin HTTP server runs on port 9001 with CORS enabled.
 Navigate to <http://localhost:9000> to see the running plugin.
 
+To view our plugin on OpenShift, navigate to the Workloads section. The plugin will be listed as **Brokers**.
+
 If you want the console to run in `https` mode, run:
 
 `yarn run start-console-tls`

--- a/console-extensions.json
+++ b/console-extensions.json
@@ -60,22 +60,13 @@
     }
   },
   {
-    "type": "console.navigation/section",
-    "properties": {
-      "id": "activemq",
-      "perspective": "admin",
-      "name": "ActiveMQ Artemis",
-      "dataAttributes": { "data-quickstart-id": "qs-nav-home" }
-    }
-  },
-  {
     "type": "console.navigation/href",
     "properties": {
       "id": "brokers",
-      "name": "ActiveMQ Artemis Self Provisioning",
+      "name": "Brokers",
       "href": "/k8s/all-namespaces/brokers",
       "perspective": "admin",
-      "section": "activemq"
+      "section": "workloads"
     }
   }
 ]


### PR DESCRIPTION
Since Brokers are a type of workload, a shortcut to our project has been added within the Workloads section as 'Brokers' which displays a list of brokers.

fixes: [#294](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/294)