### PR TITLE
Integration of broker creation form within OpenShift

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -68,5 +68,16 @@
       "perspective": "admin",
       "section": "workloads"
     }
+  },
+  {
+    "type": "console.resource/create",
+    "properties": {
+      "model": {
+        "group": "broker.amq.io",
+        "version": "v1beta1",
+        "kind": "ActiveMQArtemis"
+      },
+      "component":  { "$codeRef": "AddBrokerContainer.AddBrokerPage" }
+    }
   }
 ]


### PR DESCRIPTION
- Added integration of our custom broker creation form within OpenShift. It allows users to create brokers from multiple locations, such as through the OpenShift search results or from the Installed Operators section.

- Users can now utilize our custom broker form to create brokers in both instances.

![Screenshot from 2024-09-26 14-33-48](https://github.com/user-attachments/assets/a06a9753-54df-4c05-b822-8df8a0814140)


fixes: [#292](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/292)