### PR TITLE
Integration of the custom broker edition form within OpenShift

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -18,10 +18,12 @@
   {
     "type": "console.page/route",
     "properties": {
-      "exact": true,
+      "exact": false,
       "path": [
         "/k8s/ns/:ns/edit-broker/:name",
-        "/k8s/all-namespaces/edit-broker/:name"
+        "/k8s/all-namespaces/edit-broker/:name",
+        "/k8s/ns/:ns/broker.amq.io~v1beta1~ActiveMQArtemis/:name",
+        "/k8s/ns/:ns/clusterserviceversions/:operator/broker.amq.io~v1beta1~ActiveMQArtemis/:name"
       ],
       "component": { "$codeRef": "UpdateBrokerContainer.UpdateBrokerPage" }
     }


### PR DESCRIPTION
- Added integration of our custom broker-edition form within OpenShift. It allows users to edit brokers from multiple locations, such as through the OpenShift search results or from the Installed Operators section.

- Users can now utilize our custom broker-edition form to edit brokers in both instances.

![Screenshot from 2024-10-01 13-54-58](https://github.com/user-attachments/assets/1cfc0e30-d3fa-4148-a4ac-c29699315640)

![Screenshot from 2024-10-01 13-55-20](https://github.com/user-attachments/assets/88d96327-c613-45d7-b4d7-9f2f93bc6fab)