### PR TITLE
Move Brokers Entry After StatefulSets in the Workloads Section

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -65,6 +65,7 @@
       "id": "brokers",
       "name": "Brokers",
       "href": "/k8s/all-namespaces/brokers",
+      "insertAfter": "statefulsets",
       "perspective": "admin",
       "section": "workloads"
     }


### PR DESCRIPTION
Reordered `Brokers` Entry to Follow StatefulSets in the Workloads Section.

![Screenshot from 2024-10-01 14-13-44](https://github.com/user-attachments/assets/e3daadce-da92-4075-aa97-87e19bcb01ab)


fixes: [#305](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/305)