### PR TITLE
Fix redirect path issue for AddBrokerPage in the Openshift console

### DIFF
--- a/src/brokers/add-broker/AddBroker.container.tsx
+++ b/src/brokers/add-broker/AddBroker.container.tsx
@@ -29,19 +29,26 @@ export const AddBrokerPage: FC = () => {
   const [brokerModel, dispatch] = useReducer(artemisCrReducer, initialValues);
 
   const params = new URLSearchParams(location.search);
-  const returnUrl = params.get('returnUrl') || '/k8s/all-namespaces/brokers';
+  const returnUrl = params.get('returnUrl');
+
   const handleRedirect = () => {
-    navigate(returnUrl);
+    if (returnUrl) {
+      navigate(returnUrl);
+    } else {
+      navigate(-1);
+    }
   };
 
-  const [hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
+  const [_hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
   const [alert, setAlert] = useState('');
+
   const k8sCreateBroker = (content: BrokerCR) => {
     k8sCreate({ model: AMQBrokerModel, data: content })
       .then(
         () => {
           setAlert('');
           setHasBrokerUpdated(true);
+          handleRedirect();
         },
         (reason: Error) => {
           setAlert(reason.message);
@@ -72,10 +79,6 @@ export const AddBrokerPage: FC = () => {
       },
     });
     setIsDomainSet(true);
-  }
-
-  if (hasBrokerUpdated && alert === '') {
-    handleRedirect();
   }
 
   return (

--- a/src/brokers/view-brokers/components/BrokersList/BrokersList.tsx
+++ b/src/brokers/view-brokers/components/BrokersList/BrokersList.tsx
@@ -104,7 +104,11 @@ const BrokersList: FC<BrokersListProps> = ({
   return (
     <>
       <ListPageHeader title={t('Brokers')}>
-        <ListPageCreateLink to={`/k8s/ns/${namespace || 'default'}/add-broker`}>
+        <ListPageCreateLink
+          to={`/k8s/ns/${
+            namespace || 'default'
+          }/add-broker?returnUrl=${encodeURIComponent(location.pathname)}`}
+        >
           {t('Create Broker')}
         </ListPageCreateLink>
       </ListPageHeader>


### PR DESCRIPTION
Updated the handleRedirect logic so that the redirection always navigates back to the previous location after successful broker creation or cancellation, across all instances where the custom form is used.