### PR TITLE
Overhaul the integration of the broker edition form within Openshift

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -18,10 +18,12 @@
   {
     "type": "console.page/route",
     "properties": {
-      "exact": true,
+      "exact": false,
       "path": [
         "/k8s/ns/:ns/edit-broker/:name",
-        "/k8s/all-namespaces/edit-broker/:name"
+        "/k8s/all-namespaces/edit-broker/:name",
+        "/k8s/ns/:ns/broker.amq.io~v1beta1~ActiveMQArtemis/:name",
+        "/k8s/ns/:ns/clusterserviceversions/:operator/broker.amq.io~v1beta1~ActiveMQArtemis/:name"
       ],
       "component": { "$codeRef": "UpdateBrokerContainer.UpdateBrokerPage" }
     }

--- a/src/brokers/update-broker/UpdateBroker.container.tsx
+++ b/src/brokers/update-broker/UpdateBroker.container.tsx
@@ -29,10 +29,15 @@ export const UpdateBrokerPage: FC = () => {
   const [hasBrokerUpdated, setHasBrokerUpdated] = useState(false);
   const [alert, setAlert] = useState('');
   const params = new URLSearchParams(location.search);
-  const returnUrl = params.get('returnUrl') || '/k8s/all-namespaces/brokers';
+  const returnUrl = params.get('returnUrl');
   const handleRedirect = () => {
-    navigate(returnUrl);
+    if (returnUrl) {
+      navigate(returnUrl);
+    } else {
+      navigate(-1);
+    }
   };
+
   const k8sUpdateBroker = (content: BrokerCR) => {
     k8sUpdate({
       model: AMQBrokerModel,


### PR DESCRIPTION
- Added integration of our custom broker-edition form within OpenShift. It allows users to edit brokers from multiple locations, such as through the OpenShift search results or from the Installed Operators section.
- Users can now utilize our custom broker-edition form to edit brokers in both the instances. and also updated redirect paths to points to the previous location.

fixes: [#293](https://github.com/artemiscloud/activemq-artemis-self-provisioning-plugin/issues/293)