### PR TITLE
Update Dockerfile base image to nodejs-20

### DIFF
--- a/.devcontainer/Dockerfile.plugin
+++ b/.devcontainer/Dockerfile.plugin
@@ -1,2 +1,2 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:16 as build
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:20 as build-image
 COPY --from=openshift/origin-cli:latest /usr/bin/oc /usr/local/bin/oc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-16:latest AS build
+FROM registry.access.redhat.com/ubi8/nodejs-20:latest AS build-image
 
 ### BEGIN REMOTE SOURCE
 # Use the COPY instruction only inside the REMOTE SOURCE block
@@ -20,11 +20,16 @@ RUN mkdir -p /usr/src/
 RUN cp -r $REMOTE_SOURCES_DIR/activemq-artemis-self-provisioning-plugin/app /usr/src/
 WORKDIR /usr/src/app
 
-RUN yarn install --network-timeout 1000000 && yarn build
+## Install dependencies
+RUN yarn install --network-timeout 1000000
+
+## Build application
+RUN yarn build
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 
-COPY --from=build /usr/src/app/dist /usr/share/nginx/html
+COPY --from=build-image /usr/src/app/dist /usr/share/nginx/html
+
 USER 1001
 
 ENTRYPOINT ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
The previous base image used nodejs-16, which is outdated. Updated the base image to use nodejs-20 to ensure compatibility and support.