### PR TITLE
Deployment should add plugin and remove on undeploy

### DIFF
--- a/deploy-plugin.sh
+++ b/deploy-plugin.sh
@@ -49,4 +49,4 @@ else
   oc kustomize deploy/http | sed "s|image: .*|image: ${PLUGIN_IMAGE}|" | oc apply -f -
 fi
 
-oc patch consoles.operator.openshift.io cluster --patch '{ "spec": { "plugins": ["activemq-artemis-self-provisioning-plugin"] } }' --type=merge
+oc patch consoles.operator.openshift.io cluster --type=json --patch '[{ "op": "add", "path": "/spec/plugins/-", "value": "activemq-artemis-self-provisioning-plugin" }]'

--- a/undeploy-plugin.sh
+++ b/undeploy-plugin.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env sh
 
 oc kustomize deploy/base | oc delete -f -
+
+# remove only our plugin from list of deployed plugins
+plugins=$(oc get consoles.operator.openshift.io cluster -o json | jq -c '.spec.plugins | map(select(. != "activemq-artemis-self-provisioning-plugin"))' )
+patchPath="{ \"spec\": { \"plugins\": $plugins } }"
+oc patch consoles.operator.openshift.io cluster --type=merge --patch "${patchPath}"


### PR DESCRIPTION
This should make sure we won't accidentally remove user deployed plugins during un/deployment of our plugin.